### PR TITLE
allows disabling the cron scheduler via settings

### DIFF
--- a/src/mosquito.cr
+++ b/src/mosquito.cr
@@ -9,6 +9,8 @@ module Mosquito
     setting idle_wait : Float64 = 0.1
     setting successful_job_ttl : Int32 = 1
     setting failed_job_ttl : Int32 = 86400
+
+    setting run_cron_scheduler : Bool = true
   end
 
   class HabitatSettings

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -96,6 +96,7 @@ module Mosquito
     end
 
     private def enqueue_periodic_tasks
+      return unless Mosquito.settings.run_cron_scheduler
       run_at_most every: 1.second, label: :enqueue_periodic_tasks do |now|
         Base.scheduled_tasks.each do |scheduled_task|
           scheduled_task.try_to_execute


### PR DESCRIPTION
This doesn't completely fix #2 but addresses an inherent problem around the cron scheduler which prevents horizontally scaled mosquito runner architectures.

**Problem**: When running a cluster of workers each worker will try to enqueue cron-scheduled tasks. This results in N enqueues for N workers, which isn't right if you're trying to enqueue a job to run once an hour.

**Solution**: A setting is added to the config block which disables the cron scheduler by early exit. 

```crystal
Mosquito.configure do |settings|
  settings.run_cron_scheduler = ENV["MOSQUITO_SCHEDULER"]? || false
end
```

This allows a primitive but workable solution, as long as the deployment infrastructure will guarantee that a worker with the configuration required will be respawn in the event of a failure. Given the myriad of deployment infrastructure which support this paradigm (Heroku, Kubernetes, ECS, Fargate, etc) I think this is a reasonable solution.