### PR TITLE
adds a setting to whitelist the runnable queues for a worker

### DIFF
--- a/src/mosquito.cr
+++ b/src/mosquito.cr
@@ -11,6 +11,7 @@ module Mosquito
     setting failed_job_ttl : Int32 = 86400
 
     setting run_cron_scheduler : Bool = true
+    setting run_from : Array(String) = [] of String
   end
 
   class HabitatSettings

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -91,7 +91,16 @@ module Mosquito
 
     private def fetch_queues
       run_at_most every: 0.25.seconds, label: :fetch_queues do |t|
-        @queues = Queue.list_queues.map { |name| Queue.new name }
+        candidate_queues = Queue.list_queues.map { |name| Queue.new name }
+        @queues = filter_queues(candidate_queues)
+      end
+    end
+
+    private def filter_queues(present_queues : Array(Mosquito::Queue))
+      permitted_queues = Mosquito.settings.run_from
+      return present_queues if permitted_queues.empty?
+      present_queues.select do |queue|
+        permitted_queues.includes? queue.name
       end
     end
 

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -99,7 +99,7 @@ module Mosquito
     private def filter_queues(present_queues : Array(Mosquito::Queue))
       permitted_queues = Mosquito.settings.run_from
       return present_queues if permitted_queues.empty?
-      present_queues.select do |queue|
+      present_queues.select! do |queue|
         permitted_queues.includes? queue.name
       end
     end

--- a/test/mosquito/runner/fetch_queues_test.cr
+++ b/test/mosquito/runner/fetch_queues_test.cr
@@ -17,4 +17,18 @@ describe "Mosquito::Runner#fetch_queues" do
 
     assert_equal %w|test1 test2 test3|, runner.queues.map(&.name).sort
   end
+
+  it "filters the list of queues when a whitelist is present" do
+    with_fresh_redis do
+      redis.set "mosquito:waiting:test1", 1
+      redis.set "mosquito:waiting:test2", 1
+      redis.set "mosquito:waiting:test3", 1
+
+      Mosquito.temp_config(run_from: ["test1", "test3"]) do
+        runner.run :fetch_queues
+      end
+
+      assert_equal %w|test1 test3|, runner.queues.map(&.name).sort
+    end
+  end
 end


### PR DESCRIPTION
fixes #2 

When running a worker it's not unreasonable to want to restrict the queues from which it'll execute tasks. This provides a setting which allows whitelisting queue names for monitoring:

```crystal
Mosquito.configure do |settings|
  settings.run_from = ["slow_queries"]
end
```

The setting default is `[]` which translates to "run everything". I deliberately didn't implement the spec proposed in #2 to use a regex to filter the queue name because it seems like overkill. I can't imagine a scenario where there are enough queues where filtering explicitly is a configuration maintenance burden. 