### PR TITLE
Update to the latest redis shard version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -15,7 +15,7 @@ targets:
 dependencies:
   redis:
     github: stefanwille/crystal-redis
-    version: ~> 2.7.0
+    version: ~> 2.8.0
   habitat:
     github: luckyframework/habitat
     version: ~> 0.4.7

--- a/src/mosquito/redis.cr
+++ b/src/mosquito/redis.cr
@@ -42,20 +42,11 @@ module Mosquito
     end
 
     def store_hash(name : String, hash : Hash(String, String))
-      hash.each do |key, value|
-        hset(name, key, value)
-      end
+      hset(name, hash)
     end
 
     def retrieve_hash(name : String) : Hash(String, String)
-      data = hgetall(name)
-      hash = {} of String => String
-
-      data.each_slice(2) do |slice|
-        hash[slice[0].to_s] = slice[1].to_s
-      end
-
-      hash
+      hgetall(name)
     end
 
     forward_missing_to @connection


### PR DESCRIPTION
With the release of `2.8.0` these methods are no longer required https://github.com/stefanwille/crystal-redis/releases/tag/v2.8.0 However, they are called quite a bit, and there will need to be some re-work to switch over the calls.