### PR TITLE
Moves Job retry logic into Job where it can be overridden.

### DIFF
--- a/src/mosquito/job.cr
+++ b/src/mosquito/job.cr
@@ -83,8 +83,30 @@ module Mosquito
     end
 
     # abstract, override if desired.
+    #
+    # True if this job is rescheduleable, false if not.
     def rescheduleable? : Bool
       true
     end
+
+    # abstract, override if desired.
+    #
+    # For a given retry count, is this job rescheduleable?
+    def rescheduleable?(retry_count : Int32) : Bool
+      rescheduleable? && retry_count < 5
+    end
+
+    # abstract, override if desired.
+    #
+    # For a given retry count, how long should the delay between
+    # job attempts be?
+    def reschedule_interval(retry_count : Int32) : Time::Span
+      2.seconds * (retry_count ** 2)
+      # retry 1 = 2 minutes
+      #       2 = 8
+      #       3 = 18
+      #       4 = 32
+    end
+
   end
 end

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -47,21 +47,6 @@ module Mosquito
       @start_time = Time.utc.to_unix
     end
 
-    # Message to be removed after version 0.12.0
-    def self.idle_wait=(idle_wait)
-      raise <<-error
-      Mosquito runner Idle Wait Time is no longer configured via Mosquito::Runner.idle_wait=(n).
-
-      Idle Wait Time is configured using the configuration block.
-
-      See: https://github.com/mosquito-cr/mosquito/wiki/Advanced-Runner-Configuration
-      error
-    end
-
-    def idle_wait=(time_span : Time::Span)
-      self.idle_wait = time_span.total_seconds
-    end
-
     private def idle
       delta = Time.utc.to_unix - @start_time
       if delta < idle_wait

--- a/src/mosquito/task.cr
+++ b/src/mosquito/task.cr
@@ -85,15 +85,11 @@ module Mosquito
     end
 
     def rescheduleable?
-      @job.rescheduleable? && @retry_count < 5
+      job.rescheduleable? @retry_count
     end
 
     def reschedule_interval
-      2.seconds * (@retry_count ** 2)
-      # retry 1 = 2 minutes
-      #       2 = 8
-      #       3 = 18
-      #       4 = 32
+      job.reschedule_interval @retry_count
     end
 
     delegate :executed?, :succeeded?, :failed?, :failed, :rescheduled, to: @job

--- a/test/helpers/mocks.cr
+++ b/test/helpers/mocks.cr
@@ -28,6 +28,12 @@ module Mosquito
       include PerformanceCounter
       params()
     end
+
+    class CustomRescheduleIntervalJob < JobWithPerformanceCounter
+      def reschedule_interval(retry_count)
+        4.seconds
+      end
+    end
   end
 end
 

--- a/test/mosquito/job_test.cr
+++ b/test/mosquito/job_test.cr
@@ -65,4 +65,28 @@ describe Mosquito::Job do
   it "fetches the named queue" do
     assert_equal "default", NilJob.queue.name
   end
+
+  describe "reschedule interval" do
+    it "calculates reschedule interval correctly" do
+      intervals = {
+        1 => 2,
+        2 => 8,
+        3 => 18,
+        4 => 32
+      }
+
+      intervals.each do |count, delay|
+        assert_equal delay.seconds, passing_job.reschedule_interval(count)
+      end
+    end
+
+
+    it "allows overriding the reschedule interval" do
+      intervals = 1..4
+
+      intervals.each do |count|
+        assert_equal 4.seconds, Mosquito::TestJobs::CustomRescheduleIntervalJob.new.reschedule_interval(count)
+      end
+    end
+  end
 end

--- a/test/mosquito/runner/idle_wait_test.cr
+++ b/test/mosquito/runner/idle_wait_test.cr
@@ -13,16 +13,4 @@ describe "Mosquito::Runner#idle_wait" do
 
     assert_in_delta(runner.idle_wait, elapsed_time.total_seconds, delta: 0.02)
   end
-
-  it "sets idle_wait correctly" do
-    runner.idle_wait = 2.seconds
-
-    runner.run :start_time
-
-    elapsed_time = Time.measure do
-      runner.run :idle
-    end
-
-    assert_in_delta(runner.idle_wait, elapsed_time.total_seconds, delta: 0.02)
-  end
 end


### PR DESCRIPTION
fixes #59 

This is not strictly part of my push for v2, but it was a small pull request for a feature I've needed a time or two.

I considered moving all of the retry logic to the metaclass since I have a feeling it will be nearly universally constant, but it isn't difficult to imagine scenarios where the response to those questions should be dynamic. 