### PR TITLE
implements a general purpose job metadata store

### DIFF
--- a/demo/jobs/custom_serializers.cr
+++ b/demo/jobs/custom_serializers.cr
@@ -3,9 +3,7 @@ class CustomSerializersJob < Mosquito::QueuedJob
 
   def perform
     log "deserialized: #{count}"
-
-    # For integration testing
-    Mosquito::Redis.instance.incr self.class.name.underscore
+    metadata.increment "run_count"
   end
 
   def deserialize_int32(raw : String) : Int32

--- a/demo/jobs/periodically_puts.cr
+++ b/demo/jobs/periodically_puts.cr
@@ -5,7 +5,7 @@ class PeriodicallyPuts < Mosquito::PeriodicJob
     log "Hello from PeriodicallyPuts"
 
     # For integration testing
-    Mosquito::Redis.instance.incr self.class.name.underscore
+    metadata.increment "run_count"
   end
 end
 

--- a/demo/jobs/queued_job.cr
+++ b/demo/jobs/queued_job.cr
@@ -7,7 +7,7 @@ class QueuedJob < Mosquito::QueuedJob
     end
 
     # For integration testing
-    Mosquito::Redis.instance.incr self.class.name.underscore
+    metadata.increment "run_count"
   end
 end
 

--- a/demo/run.cr
+++ b/demo/run.cr
@@ -9,20 +9,11 @@ Mosquito::Redis.instance.flushall
 require "./jobs/*"
 
 def expect_run_count(klass, expected)
-  actual = Mosquito::Redis.instance.get klass.name.underscore
-  if expected.to_s != actual
-    raise "Expected #{klass.name} to have performed #{expected} times but instead it was performed #{actual} times."
+  metadata = klass.metadata.to_h
+  if (run_count = metadata["run_count"].to_i) != expected
+    raise "Expected #{klass.name} to have run_count == #{expected}.  But got #{run_count}"
   else
-    puts "#{klass.name} executed correctly."
-  end
-end
-
-def expect_executed_count(klass, expected)
-  config = Mosquito::Redis.instance.retrieve_hash(klass.queue.config_key)
-  if config["executed"] != expected
-    raise "Expected #{klass.name} to have config.executed == #{expected}.  But got #{config["executed"]}"
-  else
-    puts "#{klass.name} was throttled correctly."
+    puts "#{klass.name} was executed correctly."
   end
 end
 

--- a/src/mosquito/backend.cr
+++ b/src/mosquito/backend.cr
@@ -30,6 +30,11 @@ module Mosquito
       abstract def delete(key : String, in ttl = 0) : Nil
       abstract def expires_in(key : String) : Int64
 
+      abstract def get(key : String, field : String) : String?
+      abstract def set(key : String, field : String, value : String) : String
+      abstract def increment(key : String, field : String) : Int64
+      abstract def increment(key : String, field : String, by value : Int32) : Int64
+
       abstract def flush : Nil
     end
 

--- a/src/mosquito/job.cr
+++ b/src/mosquito/job.cr
@@ -108,5 +108,18 @@ module Mosquito
       #       4 = 32
     end
 
+    def metadata : Metadata
+      @metadata ||= begin
+        Metadata.new self.class.metadata_key
+      end
+    end
+
+    def self.metadata : Metadata
+      Metadata.new metadata_key, readonly: true
+    end
+
+    def self.metadata_key
+      Mosquito.backend.build_key "job_metadata", self.name.underscore
+    end
   end
 end

--- a/src/mosquito/metadata.cr
+++ b/src/mosquito/metadata.cr
@@ -5,7 +5,7 @@ module Mosquito
   # Each read or write incurs a round trip to the backend.
   class Metadata
     property root_key : String
-    getter readonly : Bool
+    getter? readonly : Bool
 
     def initialize(@root_key : String, @readonly = false)
     end
@@ -19,20 +19,18 @@ module Mosquito
     end
 
     def []=(key : String, value : String)
-      raise RuntimeError.new("Cannot write to metadata, readonly=true") if readonly
+      raise RuntimeError.new("Cannot write to metadata, readonly=true") if readonly?
       Mosquito.backend.set root_key, key, value
     end
 
     def increment(key)
-      raise RuntimeError.new("Cannot write to metadata, readonly=true") if readonly
+      raise RuntimeError.new("Cannot write to metadata, readonly=true") if readonly?
       Mosquito.backend.increment root_key, key
     end
 
     def decrement(key)
-      raise RuntimeError.new("Cannot write to metadata, readonly=true") if readonly
+      raise RuntimeError.new("Cannot write to metadata, readonly=true") if readonly?
       Mosquito.backend.increment root_key, key, by: -1
     end
-
-    def readonly? ; readonly ; end
   end
 end

--- a/src/mosquito/metadata.cr
+++ b/src/mosquito/metadata.cr
@@ -1,0 +1,38 @@
+module Mosquito
+  # Provides a real-time metadata store. Data is not cached, which allows
+  # multiple workers to operate on the same structures in real time.
+  #
+  # Each read or write incurs a round trip to the backend.
+  class Metadata
+    property root_key : String
+    getter readonly : Bool
+
+    def initialize(@root_key : String, @readonly = false)
+    end
+
+    def to_h : Hash(String, String)
+      Mosquito.backend.retrieve root_key
+    end
+
+    def []?(key : String) : String?
+      Mosquito.backend.get root_key, key
+    end
+
+    def []=(key : String, value : String)
+      raise RuntimeError.new("Cannot write to metadata, readonly=true") if readonly
+      Mosquito.backend.set root_key, key, value
+    end
+
+    def increment(key)
+      raise RuntimeError.new("Cannot write to metadata, readonly=true") if readonly
+      Mosquito.backend.increment root_key, key
+    end
+
+    def decrement(key)
+      raise RuntimeError.new("Cannot write to metadata, readonly=true") if readonly
+      Mosquito.backend.increment root_key, key, by: -1
+    end
+
+    def readonly? ; readonly ; end
+  end
+end

--- a/src/mosquito/redis_backend.cr
+++ b/src/mosquito/redis_backend.cr
@@ -34,6 +34,23 @@ module Mosquito
       end
     end
 
+    def self.get(key : String, field : String) : String?
+      redis.hget key, field
+    end
+
+    def self.set(key : String, field : String, value : String) : String
+      redis.hset key, field, value
+      value
+    end
+
+    def self.increment(key : String, field : String) : Int64
+      increment key, field, by: 1
+    end
+
+    def self.increment(key : String, field : String, by value : Int32) : Int64
+      redis.hincrby key, field, value
+    end
+
     def self.expires_in(key : String) : Int64
       redis.ttl key
     end

--- a/test/mosquito/job_test.cr
+++ b/test/mosquito/job_test.cr
@@ -89,4 +89,34 @@ describe Mosquito::Job do
       end
     end
   end
+
+  describe "metadata" do
+    it "returns a metadata instance" do
+      assert_instance_of Mosquito::Metadata, passing_job.metadata
+    end
+
+    it "is a memoized instance" do
+      one = passing_job.metadata
+      two = passing_job.metadata
+
+      assert_same one, two
+    end
+  end
+
+  describe "self.metadata" do
+    it "returns a metadata instance" do
+      assert PassingJob.metadata.is_a?(Mosquito::Metadata)
+    end
+
+    it "is readonly" do
+      metadata = PassingJob.metadata
+      assert metadata.readonly?
+    end
+  end
+
+  describe "self.metadata_key" do
+    it "includes the class name" do
+      assert_includes PassingJob.metadata_key, "passing_job"
+    end
+  end
 end

--- a/test/mosquito/metadata_test.cr
+++ b/test/mosquito/metadata_test.cr
@@ -1,0 +1,60 @@
+require "../test_helper"
+
+describe Mosquito::Metadata do
+  getter(store_name : String) { "test_store#{rand 1000}" }
+  getter(store : Metadata) { Metadata.new store_name }
+  getter(field : String) { "foo#{rand 1000}" }
+
+  it "increments" do
+    clean_slate do
+      store.increment field
+      value = store[field]?
+      assert_equal "1", value
+
+      store.increment field
+      value = store[field]?
+      assert_equal "2", value
+    end
+  end
+
+  it "decrements" do
+    clean_slate do
+      store.decrement field
+      value = store[field]?
+      assert_equal "-1", value
+
+      store.decrement field
+      value = store[field]?
+      assert_equal "-2", value
+    end
+  end
+
+  it "dumps to a hash" do
+    clean_slate do
+      expected = { "one" => "1", "two" => "2", "three" => "3" }
+
+      expected.each { |key, value| store[key] = value }
+
+      assert_equal expected, store.to_h
+    end
+  end
+
+  it "can be readonly" do
+    clean_slate do
+      store[field] = "truth"
+      readonly_store = Metadata.new store_name, readonly: true
+      assert_equal "truth", readonly_store[field]?
+
+      assert_raises RuntimeError do
+        readonly_store[field] = "lies"
+      end
+    end
+  end
+
+  it "can set and read a value" do
+    clean_slate do
+      store[field] = "truth"
+      assert_equal "truth", store[field]?
+    end
+  end
+end

--- a/test/mosquito/redis_backend_test.cr
+++ b/test/mosquito/redis_backend_test.cr
@@ -1,4 +1,25 @@
 require "../test_helper"
 
 describe Mosquito::RedisBackend do
+  getter(:key) { "key-#{rand 1000}" }
+  getter(:field) { "field-#{rand 1000}" }
+
+  describe "self.get and set" do
+    it "sets and retrieves a value from a hash" do
+      RedisBackend.set(key, field, "truth")
+      assert_equal "truth", RedisBackend.get(key, field)
+    end
+  end
+
+  describe "self.increment" do
+    it "adds one" do
+      RedisBackend.set(key, field, "1")
+      assert_equal 2, RedisBackend.increment(key, field)
+    end
+
+    it "can add arbitrary values" do
+      RedisBackend.set(key, field, "1")
+      assert_equal 4, RedisBackend.increment(key, field, by: 3)
+    end
+  end
 end


### PR DESCRIPTION
fixes #70 

This implements a `metadata` method on Job which can be used to track statistics, rate limit, or even implement a mutex between workers. The metadata is transparent and relies on the backend to manage any sort of concurrency conflicts. 

