### PR TITLE
implements before hooks

### DIFF
--- a/src/mosquito/job.cr
+++ b/src/mosquito/job.cr
@@ -42,6 +42,8 @@ module Mosquito
     end
 
     def run
+      before_hook
+
       raise DoubleRun.new if executed
       @executed = true
       perform
@@ -59,6 +61,26 @@ module Mosquito
     else
       increment
       @succeeded = true
+    end
+
+    def before_hook
+      # intentionally left blank
+    end
+
+    def retry_later
+      fail
+    end
+
+    macro before(&block)
+      def before_hook
+        {% if @type.methods.map(&.name).includes?(:before_hook.id) %}
+          previous_def
+        {% else %}
+          super
+        {% end %}
+
+        {{ yield }}
+      end
     end
 
     # abstract, override in a Job descendant to do something productive

--- a/src/mosquito/queued_job.cr
+++ b/src/mosquito/queued_job.cr
@@ -50,7 +50,7 @@ module Mosquito
               @{{ parameter["name"] }} : {{ parameter["simplified_type"] }}?
 
               def {{ parameter["name"] }} : {{ parameter["simplified_type"] }}
-                if %object = {{ parameter["name"] }}?
+                if ! (%object = {{ parameter["name"] }}?).nil?
                     %object
                 else
                   msg = <<-MSG
@@ -62,12 +62,12 @@ module Mosquito
                 end
               end
 
+              def {{ parameter["name"] }}=(value : {{parameter["simplified_type"]}}) : {{parameter["simplified_type"]}}
+                @{{ parameter["name"] }} = value
+              end
+
               def {{ parameter["name"] }}? : {{ parameter["simplified_type"] }} | Nil
-                if %object = @{{ parameter["name"] }}
-                  %object
-                else
-                  nil
-                end
+                @{{ parameter["name"] }}
               end
           {% end %}
 

--- a/test/helpers/mocks.cr
+++ b/test/helpers/mocks.cr
@@ -106,6 +106,31 @@ class JobWithConfig < Mosquito::Job
   end
 end
 
+class JobWithBeforeHook < Mosquito::QueuedJob
+  params(should_fail : Bool)
+
+  before do
+    log "Before Hook Executed"
+  end
+
+  before do
+    log "2nd Before Hook Executed"
+    fail if should_fail
+  end
+
+  def perform
+    log "Perform Executed"
+  end
+end
+
+class EchoJob < Mosquito::QueuedJob
+  params text : String
+
+  def perform
+    log text
+  end
+end
+
 Mosquito::Base.register_job_mapping "job_with_config", JobWithConfig
 Mosquito::Base.register_job_mapping "job_with_performance_counter", JobWithPerformanceCounter
 Mosquito::Base.register_job_mapping "failing_job", FailingJob

--- a/test/mosquito/queued_job_test.cr
+++ b/test/mosquito/queued_job_test.cr
@@ -1,7 +1,17 @@
 require "../test_helper"
 
 describe Mosquito::QueuedJob do
-  it "tests" do
-    skip
+  describe "parameters" do
+    it "can be passed in" do
+      clear_logs
+      EchoJob.new("quack").perform
+      assert_includes logs, "quack"
+    end
+
+    it "can have a boolean false passed as a parameter (and it's not assumed to be a nil)" do
+      clear_logs
+      JobWithBeforeHook.new(false).perform
+      assert_includes logs, "Perform Executed"
+    end
   end
 end


### PR DESCRIPTION
Before hooks allow splitting a jobs execution dynamics into reusable modules -- throttling, etc.

Adapted from https://github.com/luckyframework/avram/blob/ac281f490a85283eaf8b74fd23357dd70a6d7f22/src/avram/callbacks.cr#L122-L152

Thank you @paulcsmith for the reference code. 🍰 

Fixes #69 