### PR TITLE
Rate limiter module for jobs

### DIFF
--- a/demo/jobs/rate_limited_job.cr
+++ b/demo/jobs/rate_limited_job.cr
@@ -1,0 +1,19 @@
+class RateLimitedJob < Mosquito::QueuedJob
+  before do
+    log self.class.rate_limit_stats
+  end
+
+  include Mosquito::RateLimiter
+
+  throttle limit: 3, per: 10.seconds
+
+  params count : Int32
+
+  def perform
+    log @@rate_limit_key
+  end
+end
+
+15.times do
+  RateLimitedJob.new(3).enqueue
+end

--- a/demo/run.cr
+++ b/demo/run.cr
@@ -30,3 +30,4 @@ puts "Checking integration test flags..."
 expect_run_count(PeriodicallyPuts, 7)
 expect_run_count(QueuedJob, 1)
 expect_run_count(CustomSerializersJob, 3)
+expect_run_count(RateLimitedJob, 3)

--- a/src/mosquito/job.cr
+++ b/src/mosquito/job.cr
@@ -53,9 +53,15 @@ module Mosquito
       @succeeded = false
     else
       @succeeded = true
+    ensure
+      after_hook
     end
 
     def before_hook
+      # intentionally left blank
+    end
+
+    def after_hook
       # intentionally left blank
     end
 
@@ -66,6 +72,18 @@ module Mosquito
     macro before(&block)
       def before_hook
         {% if @type.methods.map(&.name).includes?(:before_hook.id) %}
+          previous_def
+        {% else %}
+          super
+        {% end %}
+
+        {{ yield }}
+      end
+    end
+
+    macro after(&block)
+      def after_hook
+        {% if @type.methods.map(&.name).includes?(:after_hook.id) %}
           previous_def
         {% else %}
           super

--- a/src/mosquito/job.cr
+++ b/src/mosquito/job.cr
@@ -111,9 +111,8 @@ module Mosquito
       @executed
     end
 
-    # Did the job run and succeed?
+    # Did the job succeed?
     def succeeded? : Bool
-      raise "Job hasn't been executed yet" unless @executed
       @succeeded
     end
 

--- a/src/mosquito/metadata.cr
+++ b/src/mosquito/metadata.cr
@@ -37,5 +37,7 @@ module Mosquito
       raise RuntimeError.new("Cannot write to metadata, readonly=true") if readonly?
       Mosquito.backend.increment root_key, key, by: -1
     end
+
+    delegate to_s, inspect, to: to_h
   end
 end

--- a/src/mosquito/metadata.cr
+++ b/src/mosquito/metadata.cr
@@ -28,6 +28,11 @@ module Mosquito
       Mosquito.backend.increment root_key, key
     end
 
+    def increment(key, by increment : Int32)
+      raise RuntimeError.new("Cannot write to metadata, readonly=true") if readonly?
+      Mosquito.backend.increment root_key, key, by: increment
+    end
+
     def decrement(key)
       raise RuntimeError.new("Cannot write to metadata, readonly=true") if readonly?
       Mosquito.backend.increment root_key, key, by: -1

--- a/src/mosquito/queued_job.cr
+++ b/src/mosquito/queued_job.cr
@@ -82,7 +82,7 @@ module Mosquito
               parsed_parameters.map do |parameter|
                 assignment = "@#{parameter["name"]}"
                 assignment = assignment + " : #{parameter["type"]}" if parameter["type"]
-                assignment = assignment + " = #{parameter["value"]}" if parameter["value"]
+                assignment = assignment + " = #{parameter["value"]}" unless parameter["value"].is_a? Nop
                 assignment
               end.join(", ").id
               }})

--- a/src/mosquito/rate_limiter.cr
+++ b/src/mosquito/rate_limiter.cr
@@ -1,0 +1,135 @@
+module Mosquito::RateLimiter
+  module ClassMethods
+    # Configures rate limiting for this job.
+    #
+    # `limit` and `per` are used to control the run count and the window
+    # duration. Defaults to a limit of 1 run per second.
+    #
+    # `increment` is used to indicate how many "hits" against a single job is
+    # worth. Defaults to 1.
+    #
+    # `key` is used to combine rate limiting functions across multiple jobs.
+    def throttle(*,
+      limit : Int32 = 1,
+      per : Time::Span = 1.second,
+      increment = 1,
+      key = self.name.underscore
+    )
+      @@rate_limit_ceiling = limit
+      @@rate_limit_interval = per
+      @@rate_limit_key = Mosquito.backend.build_key "rate_limit", key
+      @@rate_limit_increment = increment
+    end
+
+    # Storage hash for rate limit data.
+    def rate_limit_data : Metadata
+      Metadata.new @@rate_limit_key
+    end
+
+    def rate_limit_key
+      @@rate_limit_key
+    end
+  end
+
+  macro included
+    extend ClassMethods
+
+    @@rate_limit_ceiling = -1
+    @@rate_limit_interval : Time::Span = 1.second
+    @@rate_limit_key = ""
+    @@rate_limit_increment = 1
+
+    before do
+      update_window_start
+      retry_later if rate_limited?
+    end
+
+    after do
+      increment_run_count if executed?
+    end
+  end
+
+  # Storage hash for rate limit data.
+  @rate_limit_data : Metadata?
+  def rate_limit_data : Metadata
+    @rate_limit_data ||= self.class.rate_limit_data
+  end
+
+  # Should this job be cancelled?
+  # If not, update the rate limit metadata.
+  def rate_limited? : Bool
+    return false if @@rate_limit_ceiling < 0
+    return true if maxed_rate_for_window?
+    false
+  end
+
+  # Has the run count exceeded the ceiling for the current window?
+  def maxed_rate_for_window? : Bool
+    run_count = rate_limit_data["run_count"]?.try &.to_i
+    run_count ||= 0
+    run_count >= @@rate_limit_ceiling
+  end
+
+  # Calculates the start of the rate limit window.
+  def window_start : Time?
+    if start_time = rate_limit_data["window_start"]?.try(&.to_i)
+      Time.unix start_time
+    end
+  end
+
+  # When does the current rate limit window expire?
+  # Returns nil if the window is already expired.
+  def window_expires_at : Time?
+    return nil unless started_window = window_start
+    expiration_time = started_window + @@rate_limit_interval
+
+    if expiration_time < Time.utc
+      nil
+    else
+      expiration_time
+    end
+  end
+
+  # Resets the run count and logs the start of window.
+  def update_window_start : Nil
+    started_window = window_start || Time::UNIX_EPOCH
+    now = Time.utc
+    if (now - started_window) > @@rate_limit_interval
+      rate_limit_data["window_start"] = now.to_unix.to_s
+      rate_limit_data["run_count"] = "0"
+    end
+  end
+
+  # Increments the run counter.
+  def increment_run_count : Nil
+    rate_limit_data.increment "run_count", by: increment_run_count_by
+  end
+
+  # How much the run counter should be incremented by.
+  # Implemented as a dynamic method so that it can easily be calculated by
+  # some other metric, eg api calls to a third party library.
+  def increment_run_count_by : Int32
+    @@rate_limit_increment
+  end
+
+  # Configure the reschedule interval so that the task is not run again until it
+  # should be allowed through the rate limiter.
+  def reschedule_interval(retry_count : Int32) : Time::Span
+    if rate_limited? && (window_expiration = window_expires_at)
+      next_window =  window_expiration - Time.utc
+      log "Rate limited: will run again in #{next_window}"
+      next_window
+    else
+      super
+    end
+  end
+
+  # Configure the rescheduler to always retry if a job is rate limited.
+  def rescheduleable?(retry_count : Int32) : Bool
+    if rate_limited?
+      true
+    else
+      super
+    end
+  end
+end

--- a/src/mosquito/task.cr
+++ b/src/mosquito/task.cr
@@ -73,7 +73,7 @@ module Mosquito
       instance = build_job
       instance.run
 
-      if failed?
+      if executed? && failed?
         @retry_count += 1
         store
       end

--- a/test/helpers/mocks.cr
+++ b/test/helpers/mocks.cr
@@ -114,6 +114,38 @@ class EchoJob < Mosquito::QueuedJob
   end
 end
 
+class RateLimitedJob < Mosquito::QueuedJob
+  include Mosquito::RateLimiter
+
+  throttle key: "rate_limit", limit: Int32::MAX
+
+  params should_fail : Bool = false, increment : Int32 = 1
+
+  before do
+    log "Before Hook Executed"
+    fail if should_fail
+  end
+
+  def perform
+    log "Performed"
+  end
+
+  def increment_run_count_by
+    increment
+  end
+end
+
+class SecondRateLimitedJob < Mosquito::QueuedJob
+  include Mosquito::RateLimiter
+
+  throttle key: "rate_limit", limit: Int32::MAX
+
+  params()
+
+  def perform
+  end
+end
+
 Mosquito::Base.register_job_mapping "job_with_config", JobWithConfig
 Mosquito::Base.register_job_mapping "job_with_performance_counter", JobWithPerformanceCounter
 Mosquito::Base.register_job_mapping "failing_job", FailingJob

--- a/test/helpers/mocks.cr
+++ b/test/helpers/mocks.cr
@@ -81,16 +81,24 @@ class JobWithConfig < PassingJob
   end
 end
 
-class JobWithBeforeHook < Mosquito::QueuedJob
+class JobWithHooks < Mosquito::QueuedJob
   params(should_fail : Bool)
 
   before do
     log "Before Hook Executed"
   end
 
+  after do
+    log "After Hook Executed"
+  end
+
   before do
     log "2nd Before Hook Executed"
     fail if should_fail
+  end
+
+  after do
+    log "2nd After Hook Executed"
   end
 
   def perform

--- a/test/mosquito/job_test.cr
+++ b/test/mosquito/job_test.cr
@@ -6,14 +6,6 @@ describe Mosquito::Job do
   let(:not_implemented_job) { NotImplementedJob.new }
 
   let(:throttled_job) { ThrottledJob.new }
-
-  it "raises when asked if #succeeded? before execution" do
-    exception = assert_raises do
-      passing_job.succeeded?
-    end
-
-    assert_match /hasn't been executed/, exception.message
-  end
   let(:hooked_job) { JobWithHooks.new }
 
   it "run captures JobFailed and marks sucess=false" do

--- a/test/mosquito/metadata_test.cr
+++ b/test/mosquito/metadata_test.cr
@@ -17,6 +17,19 @@ describe Mosquito::Metadata do
     end
   end
 
+  it "increments with a configurable amount" do
+    clean_slate do
+      store.increment field
+      value = store[field]?.not_nil!
+      assert_equal "1", value
+
+      delta = 2
+      store.increment field, by: delta
+      new_value = store[field]?.not_nil!
+      assert_equal delta, (new_value.to_i - value.to_i)
+    end
+  end
+
   it "decrements" do
     clean_slate do
       store.decrement field

--- a/test/mosquito/queued_job_test.cr
+++ b/test/mosquito/queued_job_test.cr
@@ -39,7 +39,7 @@ describe Mosquito::QueuedJob do
 
     it "can have a boolean false passed as a parameter (and it's not assumed to be a nil)" do
       clear_logs
-      JobWithBeforeHook.new(false).perform
+      JobWithHooks.new(false).perform
       assert_includes logs, "Perform Executed"
     end
   end

--- a/test/mosquito/rate_limiter_test.cr
+++ b/test/mosquito/rate_limiter_test.cr
@@ -1,0 +1,146 @@
+require "../test_helper"
+
+describe Mosquito::RateLimiter do
+  describe "RateLimiter.rate_limit_stats" do
+    it "provides the state and configuration of the limiter" do
+      clean_slate do
+        stats = RateLimitedJob.rate_limit_stats
+        assert stats.has_key? :interval
+        assert stats.has_key? :key
+        assert stats.has_key? :increment
+        assert stats.has_key? :limit
+        assert stats.has_key? :window_start
+        assert stats.has_key? :run_count
+      end
+    end
+
+    it "defaults the window_start" do
+      clean_slate do
+        assert_equal Time::UNIX_EPOCH, RateLimitedJob.rate_limit_stats[:window_start]
+
+        now = Time.utc.at_beginning_of_second
+        RateLimitedJob.metadata["window_start"] = now.to_unix.to_s
+        assert_equal now, RateLimitedJob.rate_limit_stats[:window_start]
+      end
+    end
+
+    it "defaults the run_count" do
+      clean_slate do
+        assert_equal 0, RateLimitedJob.rate_limit_stats[:run_count]
+
+        run_count = 27
+        RateLimitedJob.metadata["run_count"] = run_count.to_s
+        assert_equal run_count, RateLimitedJob.rate_limit_stats[:run_count]
+      end
+    end
+  end
+
+  describe "RateLimiter.metadata" do
+    it "provides an instance of the metadata store" do
+      assert_instance_of Metadata, RateLimitedJob.metadata
+    end
+  end
+
+  describe "RateLimiter.rate_limit_key" do
+    it "provides the metadata key for this class" do
+      assert_equal "mosquito:rate_limit:rate_limit", RateLimitedJob.rate_limit_key
+    end
+  end
+
+  describe "job counting" do
+    it "increments the count when a job is run" do
+      clean_slate do
+        RateLimitedJob.new.run
+        count = RateLimitedJob.rate_limit_data["run_count"]?.not_nil!.to_i
+
+        RateLimitedJob.new.run
+        new_count = RateLimitedJob.rate_limit_data["run_count"]?.not_nil!.to_i
+        assert_equal 1, new_count - count
+      end
+    end
+
+    it "doesnt increment the count when a job is not run" do
+      clean_slate do
+        RateLimitedJob.new(should_fail: false).run
+        count = RateLimitedJob.rate_limit_data["run_count"]?.not_nil!.to_i
+
+        RateLimitedJob.new(should_fail: true).run
+        new_count = RateLimitedJob.rate_limit_data["run_count"]?.not_nil!.to_i
+        assert_equal count, new_count
+      end
+    end
+
+    it "increments the count by a configurable number" do
+      clean_slate do
+        delta = 2
+        RateLimitedJob.new.run
+        count = RateLimitedJob.rate_limit_data["run_count"]?.not_nil!.to_i
+
+        RateLimitedJob.new(increment: delta).run
+        new_count = RateLimitedJob.rate_limit_data["run_count"]?.not_nil!.to_i
+        assert_equal delta, new_count - count
+      end
+    end
+
+    it "resets the count when the window is over" do
+      clean_slate do
+        metadata = RateLimitedJob.rate_limit_data
+        metadata["run_count"] = "45"
+        metadata["window_start"] = Time::UNIX_EPOCH.to_unix.to_s
+        RateLimitedJob.new.run
+        count = RateLimitedJob.rate_limit_data["run_count"]?
+        assert_equal "1", count
+      end
+    end
+
+    it "counts multiple jobs with the same key in the same bucket" do
+      clean_slate do
+        RateLimitedJob.new.run
+        count = RateLimitedJob.rate_limit_data["run_count"]?.not_nil!.to_i
+
+        SecondRateLimitedJob.new.run
+        new_count = RateLimitedJob.rate_limit_data["run_count"]?.not_nil!.to_i
+        assert_equal RateLimitedJob.rate_limit_key, SecondRateLimitedJob.rate_limit_key
+        assert_equal 1, new_count - count
+      end
+    end
+  end
+
+  describe "job preempting" do
+    it "doesnt prevent excution if the rate limit count is less than zero" do
+      metadata = RateLimitedJob.rate_limit_data
+      metadata["run_count"] = "-1"
+      metadata["window_start"] = Time.utc.to_unix.to_s
+      job = RateLimitedJob.new
+      job.run
+      assert job.executed?
+    end
+
+    it "prevents a job from executing when the limit is reached" do
+      metadata = RateLimitedJob.rate_limit_data
+      metadata["run_count"] = Int32::MAX.to_s
+      metadata["window_start"] = Time.utc.to_unix.to_s
+      job = RateLimitedJob.new
+      job.run
+      refute job.executed?
+    end
+
+    it "allows a job to execute when the limit hasn't been reached" do
+      metadata = RateLimitedJob.rate_limit_data
+      metadata["window_start"] = Time.utc.to_unix.to_s
+      metadata["run_count"] = "3"
+      job = RateLimitedJob.new
+      job.run
+      assert job.executed?
+    end
+
+    it "allows a job to execute when the limit has been reached but the window is over" do
+      metadata = RateLimitedJob.rate_limit_data
+      metadata["run_count"] = Int32::MAX.to_s
+      metadata["window_start"] = Time::UNIX_EPOCH.to_unix.to_s
+      job = RateLimitedJob.new
+      job.run
+      assert job.executed?
+    end
+  end
+end


### PR DESCRIPTION
This is a re-implementation of the throttling logic introduced in v0.4.0 via #20, but implemented as a decorator module.

The throttling configuration syntax is concise: 

```crystal
class RateLimitedJob < Mosquito::QueuedJob
  include Mosquito::RateLimiter

  throttle limit: 1, per: 10.seconds

  params blah : Int32

  def perform
    # etc...
  end
end
```

Highlights:
- Leverages `before` hook introduced in 7de390cf160756c16cbd360975786fb4fc698b66 (v0.11.1) so the interface is transparent, and doesn't have any performance penalty on jobs which don't need rate limiting.
- Leverages metadata store introduced in ae67378f9b7c5acaee60fb7df36816e26ea09a8c. The rate limit configuration logic is no longer dangling off of Queue.
- The rate limit key is now override-able, which means that multiple jobs can share the same rate limit counters. This hopefully will be useful for guarding against 3rd api usage guidelines.

Ancillary improvements:
- Implements `after` hooks, by copying and pasting the `before` hook code and tests.
- Extends metadata#increment to allow passing in an increment value.
- Fixes a latent bug where `false` could not be set as the default value for a job parameter.