### PR TITLE
Provides a shutdown method on the runner class

### DIFF
--- a/demo/run.cr
+++ b/demo/run.cr
@@ -17,11 +17,16 @@ def expect_run_count(klass, expected)
   end
 end
 
+Signal::INT.trap do
+  Mosquito::Runner.stop
+end
+
 spawn do
   Mosquito::Runner.start
 end
 
 sleep 21
+Mosquito::Runner.stop
 
 puts "End of demo."
 puts "----------------------------------"

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -11,16 +11,25 @@ module Mosquito
     # How long a job config is persisted after failure
     property failed_job_ttl : Int32
 
+    # Should the worker continue working?
+    class_property keep_running : Bool = true
+
+    getter queues, start_time
+
     def self.start
       Log.info { "Mosquito is buzzing..." }
       instance = new
 
       while true
         instance.run
+        break unless @@keep_running
       end
     end
 
-    getter queues, start_time
+    def self.stop
+      Log.info { "Mosquito is shutting down..." }
+      @@keep_running = false
+    end
 
     def initialize
       Mosquito.validate_settings


### PR DESCRIPTION
This rudimentary interface should help avoid the problem of interrupting a job mid-execution. Fixes #21.