### PR TITLE
Logging enhancements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,16 @@ on:
   pull_request:
     branches:
       - master
-      - v2_rc
   push:
     branches:
       - master
-      - v2_rc
 
 jobs:
   build:
     strategy:
       fail-fast: false
       matrix:
-        crystal_version: [1.1, 1.2, latest]
+        crystal_version: [1.1, latest]
         experimental:
           - false
         include:

--- a/src/mosquito/job.cr
+++ b/src/mosquito/job.cr
@@ -58,8 +58,11 @@ module Mosquito
       raise DoubleRun.new if executed
       @executed = true
       perform
-    rescue JobFailed
+    rescue e : JobFailed
       @succeeded = false
+      Log.error {
+        "Job failed: #{e.message}"
+      }
     rescue e : DoubleRun
       raise e
     rescue e
@@ -119,8 +122,8 @@ module Mosquito
     # To be called from inside a #perform
     # Marks this job as a failure. If the job is a candidate for
     # re-scheduling, it will be run again at a later time.
-    def fail
-      raise JobFailed.new
+    def fail(reason = "")
+      raise JobFailed.new(reason)
     end
 
     # Did the job execute?

--- a/src/mosquito/periodic_task.cr
+++ b/src/mosquito/periodic_task.cr
@@ -8,12 +8,15 @@ module Mosquito
       @last_executed_at = Time.unix 0
     end
 
-    def try_to_execute : Nil
+    def try_to_execute : Bool
       now = Time.utc
 
       if last_executed_at + interval <= now
         execute
         @last_executed_at = now
+        true
+      else
+        false
       end
     end
 

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -173,7 +173,7 @@ module Mosquito
               s << "will run again".colorize.cyan
               s << " in "
               s << task.reschedule_interval
-              s << "( at "
+              s << " (at "
               s << next_execution
               s << ")"
             end

--- a/src/mosquito/task.cr
+++ b/src/mosquito/task.cr
@@ -94,6 +94,7 @@ module Mosquito
 
     delegate :executed?, :succeeded?, :failed?, :failed, :rescheduled, to: @job
 
+    # Used to construct a task from the parameters stored in the backend.
     def self.retrieve(id : String)
       fields = Mosquito.backend.retrieve config_key(id)
 
@@ -105,6 +106,12 @@ module Mosquito
       instance.config = fields
 
       instance
+    end
+
+    # Updates this task config from the backend.
+    def reload : Nil
+      config.merge! Mosquito.backend.retrieve config_key
+      @retry_count = config["retry_count"].to_i
     end
 
     def to_s(io : IO)

--- a/test/helpers/logging_helper.cr
+++ b/test/helpers/logging_helper.cr
@@ -10,7 +10,10 @@ end
 
 class Minitest::Test
   def logs
-    TestingBackend.instance.entries.map(&.message).join
+    TestingBackend.instance.entries
+      .map(&.message)
+      .join('\n')
+      .gsub(/\e\[\d+(;\d+)?m/, "")
   end
 
   def clear_logs

--- a/test/helpers/logging_helper.cr
+++ b/test/helpers/logging_helper.cr
@@ -12,8 +12,29 @@ class Minitest::Test
   def logs
     TestingBackend.instance.entries
       .map(&.message)
-      .join('\n')
-      .gsub(/\e\[\d+(;\d+)?m/, "")
+      .map(&.gsub(/\e\[\d+(;\d+)?m/, "")) # remove color codes
+  end
+
+  private def logs_match(expected : Regex) : Bool
+    matched = logs.any? do |entry|
+      entry =~ expected
+    end
+  end
+
+  def assert_logs_match(expected : String)
+    assert_logs_match %r|#{expected}|
+  end
+
+  def assert_logs_match(expected : Regex)
+    assert logs_match(expected), "Expected to logs to include #{expected}. Logs contained: \n#{logs.join("\n")}"
+  end
+
+  def refute_logs_match(expected : String)
+    refute_logs_match %r|#{expected}|
+  end
+
+  def refute_logs_match(expected : Regex)
+    refute logs_match(expected), "Expected to logs to not include #{expected}. Logs contained: \n#{logs.join("\n")}"
   end
 
   def clear_logs

--- a/test/helpers/mocks.cr
+++ b/test/helpers/mocks.cr
@@ -40,6 +40,8 @@ end
 
 class FailingJob < QueuedTestJob
   property fail_with_exception = false
+  property exception_message = "this is the reason #{name} failed"
+
   include PerformanceCounter
   params()
 
@@ -49,12 +51,8 @@ class FailingJob < QueuedTestJob
     if fail_with_exception
       raise exception_message
     else
-      fail
+      fail exception_message
     end
-  end
-
-  def exception_message
-    "Job failed"
   end
 end
 

--- a/test/mosquito/job_test.cr
+++ b/test/mosquito/job_test.cr
@@ -22,6 +22,15 @@ describe Mosquito::Job do
     assert passing_job.succeeded?
   end
 
+  it "emits a failure message when #fail contains a reason message" do
+    clear_logs
+
+    failing_job.run
+    assert failing_job.failed?
+
+    assert_logs_match failing_job.exception_message
+  end
+
   it "run captures and marks failure for other exceptions" do
     clear_logs
 

--- a/test/mosquito/job_test.cr
+++ b/test/mosquito/job_test.cr
@@ -29,7 +29,7 @@ describe Mosquito::Job do
     failing_job.run
     assert failing_job.failed?
 
-    assert_includes logs, failing_job.exception_message
+    assert_logs_match failing_job.exception_message
   end
 
   it "marks success=false when #fail-ed" do
@@ -43,7 +43,7 @@ describe Mosquito::Job do
     not_implemented_job.run
     assert not_implemented_job.failed?
 
-    assert_includes logs, "No job definition found"
+    assert_logs_match "No job definition found"
   end
 
   it "raises DoubleRun if it's already been executed" do
@@ -120,9 +120,9 @@ describe Mosquito::Job do
       clear_logs
       hooked_job.should_fail = false
       hooked_job.run
-      assert_includes logs, "Before Hook Executed"
-      assert_includes logs, "2nd Before Hook Executed"
-      assert_includes logs, "Perform Executed"
+      assert_logs_match "Before Hook Executed"
+      assert_logs_match "2nd Before Hook Executed"
+      assert_logs_match "Perform Executed"
     end
 
     it "should not exec when a before hook fails the job" do
@@ -130,9 +130,9 @@ describe Mosquito::Job do
       hooked_job.should_fail = true
       hooked_job.run
 
-      assert_includes logs, "Before Hook Executed"
-      assert_includes logs, "2nd Before Hook Executed"
-      refute_includes logs, "Perform Executed"
+      assert_logs_match "Before Hook Executed"
+      assert_logs_match "2nd Before Hook Executed"
+      refute_logs_match "Perform Executed"
     end
   end
 
@@ -141,18 +141,18 @@ describe Mosquito::Job do
       clear_logs
       hooked_job.should_fail = false
       hooked_job.run
-      assert_includes logs, "After Hook Executed"
-      assert_includes logs, "2nd After Hook Executed"
-      assert_includes logs, "Perform Executed"
+      assert_logs_match "After Hook Executed"
+      assert_logs_match "2nd After Hook Executed"
+      assert_logs_match "Perform Executed"
     end
 
     it "should run the `after` hooks even if a job fails" do
       clear_logs
       hooked_job.should_fail = true
       hooked_job.run
-      assert_includes logs, "After Hook Executed"
-      assert_includes logs, "2nd After Hook Executed"
-      refute_includes logs, "Perform Executed"
+      assert_logs_match "After Hook Executed"
+      assert_logs_match "2nd After Hook Executed"
+      refute_logs_match "Perform Executed"
     end
   end
 end

--- a/test/mosquito/runner/log_messages_test.cr
+++ b/test/mosquito/runner/log_messages_test.cr
@@ -23,7 +23,7 @@ describe "Mosquito::Runner logs" do
 
         clear_logs
         run_task QueuedTestJob
-        assert_includes logs, "Success"
+        assert_logs_match "Success"
       end
     end
 
@@ -32,7 +32,7 @@ describe "Mosquito::Runner logs" do
         register_mappings
         clear_logs
         run_task FailingJob
-        assert_includes logs, "Failure"
+        assert_logs_match "Failure"
       end
     end
   end
@@ -43,7 +43,7 @@ describe "Mosquito::Runner logs" do
         register_mappings
         clear_logs
         run_task QueuedTestJob
-        assert_includes logs, "and took"
+        assert_logs_match "and took"
       end
     end
 
@@ -52,7 +52,7 @@ describe "Mosquito::Runner logs" do
         register_mappings
         clear_logs
         run_task FailingJob
-        assert_includes logs, "taking"
+        assert_logs_match "taking"
       end
     end
   end
@@ -63,7 +63,7 @@ describe "Mosquito::Runner logs" do
         register_mappings
         clear_logs
         run_task QueuedTestJob
-        assert_includes logs, "Starting: queued_test_job"
+        assert_logs_match "Starting: queued_test_job"
       end
     end
   end
@@ -76,7 +76,7 @@ describe "Mosquito::Runner logs" do
         QueuedTestJob.new.enqueue at: 1.second.ago
         runner.run :fetch_queues
         runner.run :enqueue
-        assert_includes logs, "Found 1 delayed task"
+        assert_logs_match "Found 1 delayed task"
       end
     end
   end

--- a/test/mosquito/runner/log_messages_test.cr
+++ b/test/mosquito/runner/log_messages_test.cr
@@ -1,0 +1,83 @@
+require "../../test_helper"
+
+describe "Mosquito::Runner logs" do
+  let(:runner) { Mosquito::TestableRunner.new }
+  getter backend : Mosquito::Backend { Mosquito.backend.named "test" }
+
+  def register_mappings
+    Mosquito::Base.register_job_mapping "queued_test_job", QueuedTestJob
+    Mosquito::Base.register_job_mapping "failing_job", FailingJob
+  end
+
+  def run_task(job)
+    job.new.enqueue
+
+    runner.run :fetch_queues
+    runner.run :run
+  end
+
+  describe "success/failures messages" do
+    it "logs a success message when the job succeeds" do
+      clean_slate do
+        register_mappings
+
+        clear_logs
+        run_task QueuedTestJob
+        assert_includes logs, "Success"
+      end
+    end
+
+    it "logs a failure message when the job fails" do
+      clean_slate do
+        register_mappings
+        clear_logs
+        run_task FailingJob
+        assert_includes logs, "Failure"
+      end
+    end
+  end
+
+  describe "job timing messages" do
+    it "logs the time a job took to run" do
+      clean_slate do
+        register_mappings
+        clear_logs
+        run_task QueuedTestJob
+        assert_includes logs, "and took"
+      end
+    end
+
+    it "logs the time a job took to run when the job fails" do
+      clean_slate do
+        register_mappings
+        clear_logs
+        run_task FailingJob
+        assert_includes logs, "taking"
+      end
+    end
+  end
+
+  describe "start and finish messages" do
+    it "logs the job run start message" do
+      clean_slate do
+        register_mappings
+        clear_logs
+        run_task QueuedTestJob
+        assert_includes logs, "Starting: queued_test_job"
+      end
+    end
+  end
+
+  describe "messages for finding ready delayed and scheduled jobs" do
+    it "logs when it finds delayed tasks" do
+      clean_slate do
+        register_mappings
+        clear_logs
+        QueuedTestJob.new.enqueue at: 1.second.ago
+        runner.run :fetch_queues
+        runner.run :enqueue
+        assert_includes logs, "Found 1 delayed task"
+      end
+    end
+  end
+end

--- a/test/mosquito/runner/run_tasks_test.cr
+++ b/test/mosquito/runner/run_tasks_test.cr
@@ -28,25 +28,6 @@ describe "Mosquito::Runner#run_next_task" do
     end
   end
 
-  it "logs a success message" do
-    clean_slate do
-      register_mappings
-
-      clear_logs
-      run_task QueuedTestJob
-      assert_includes logs, "Success"
-    end
-  end
-
-  it "logs a failure message" do
-    clean_slate do
-      register_mappings
-      clear_logs
-      run_task FailingJob
-      assert_includes logs, "Failure"
-    end
-  end
-
   it "reschedules a job that failed" do
     skip
   end
@@ -106,7 +87,6 @@ describe "Mosquito::Runner#run_next_task" do
       QueuedTestJob.queue.enqueue task
       ttl = Mosquito.backend.expires_in task.config_key
       assert_equal runner.successful_job_ttl, ttl
-
     end
   end
 

--- a/test/mosquito/runner/run_tasks_test.cr
+++ b/test/mosquito/runner/run_tasks_test.cr
@@ -66,7 +66,7 @@ describe "Mosquito::Runner#run_next_task" do
       runner.run :fetch_queues
       runner.run :run
 
-      assert_includes logs, "cannot be rescheduled"
+      assert_logs_match "cannot be rescheduled"
     end
   end
 
@@ -107,7 +107,7 @@ describe "Mosquito::Runner#run_next_task" do
       runner.run :fetch_queues
       runner.run :run
 
-      assert_includes logs, "Success"
+      assert_logs_match "Success"
 
       QueuedTestJob.queue.enqueue task
       ttl = Mosquito.backend.expires_in task.config_key

--- a/test/mosquito/task/storage_test.cr
+++ b/test/mosquito/task/storage_test.cr
@@ -47,4 +47,8 @@ describe "task storage" do
     set_ttl = backend.expires_in task.config_key
     assert_equal ttl, set_ttl
   end
+
+  it "can reload a task" do
+    task.reload
+  end
 end


### PR DESCRIPTION
- [x] Switches to using `Log.level {}` blocks to wrap logic dedicated for logging (cf: https://github.com/crystal-lang/crystal/pull/12000)
- [x] Improves testing helper for logging
- [x] Adds tests around runner log messages
- [x] Fix #7 