### PR TITLE
Swappable redis configuration

### DIFF
--- a/demo/run.cr
+++ b/demo/run.cr
@@ -1,7 +1,14 @@
+require "redis"
+require "../src/mosquito/redis"
+
+class Redis
+  include Mosquito::RedisInterface
+end
+
 require "../src/mosquito"
 
 Mosquito.configure do |settings|
-  settings.redis_url = ENV["REDIS_URL"]? || "redis://localhost:6379/3"
+  settings.redis_connection = Redis.new(ENV["REDIS_URL"]? || "redis://127.0.0.1:6379/3")
 end
 
 Mosquito::Redis.instance.flushall

--- a/src/mosquito/configuration.cr
+++ b/src/mosquito/configuration.cr
@@ -6,7 +6,8 @@ module Mosquito
   end
 
   class Configuration
-    property redis_url : String?
+    # property redis_url : String?
+    property redis_connection : Mosquito::RedisInterface?
     property idle_wait : Float64 = 0.1
     property successful_job_ttl : Int32 = 1
     property failed_job_ttl : Int32 = 86400
@@ -21,11 +22,16 @@ module Mosquito
       @idle_wait = time_span.total_seconds
     end
 
+    def redis_connection!
+      validate
+      redis_connection.not_nil!
+    end
+
     def validate
       return if @validated
       @validated = true
 
-      if redis_url.nil?
+      if redis_connection.nil?
         message = <<-error
         Mosquito cannot start because the redis connection string hasn't been provided.
 

--- a/src/mosquito/redis.cr
+++ b/src/mosquito/redis.cr
@@ -1,6 +1,26 @@
 require "redis"
 
 module Mosquito
+  module RedisInterface
+    abstract def del(key)
+    abstract def expire(key, seconds)
+    abstract def flushall
+    abstract def hget(key, field)
+    abstract def hgetall(key)
+    abstract def hincrby(key, field, increment)
+    abstract def hset(key, field, value)
+    abstract def keys(pattern)
+    abstract def llen(key)
+    abstract def lpush(key, value)
+    abstract def lrem(key, count, value)
+    abstract def rpoplpush(source, destination)
+    abstract def ttl(key)
+    abstract def zadd(key, score, value)
+    abstract def zcount(key, min, max)
+    abstract def zrangebyscore(key, min, max)
+    abstract def zrem(key, value)
+  end
+
   class Redis
     def self.instance
       @@instance ||= new


### PR DESCRIPTION
This is a proof-of-concept for how the redis connection dependency could be injected rather than constructed.

Benefits:
- Shared connection pool with the host application, which could translate to better horizontal scalability for a service which is constrained by the number of connections to a redis instance.
- Ability to interoperate with multiple versions of the redis shard, which simplifies upgrading mosquito/redis/your-app/your-framework

Drawbacks:
- The few extra lines of configuration required to make it work