### PR TITLE
Add persist_run_count flag

### DIFF
--- a/src/mosquito/metadata.cr
+++ b/src/mosquito/metadata.cr
@@ -38,6 +38,11 @@ module Mosquito
       Mosquito.backend.increment root_key, key, by: -1
     end
 
+    def decrement(key, by decrement : Int32)
+      raise RuntimeError.new("Cannot write to metadata, readonly=true") if readonly?
+      Mosquito.backend.decrement root_key, key, by: decrement
+    end
+
     delegate to_s, inspect, to: to_h
   end
 end

--- a/src/mosquito/metadata.cr
+++ b/src/mosquito/metadata.cr
@@ -38,11 +38,6 @@ module Mosquito
       Mosquito.backend.increment root_key, key, by: -1
     end
 
-    def decrement(key, by decrement : Int32)
-      raise RuntimeError.new("Cannot write to metadata, readonly=true") if readonly?
-      Mosquito.backend.decrement root_key, key, by: decrement
-    end
-
     delegate to_s, inspect, to: to_h
   end
 end

--- a/src/mosquito/rate_limiter.cr
+++ b/src/mosquito/rate_limiter.cr
@@ -69,6 +69,7 @@ module Mosquito::RateLimiter
     @@rate_limit_interval : Time::Span = 1.second
     @@rate_limit_key = ""
     @@rate_limit_increment = 1
+    @@persist_run_count = false
 
     before do
       update_window_start

--- a/src/mosquito/rate_limiter.cr
+++ b/src/mosquito/rate_limiter.cr
@@ -141,7 +141,7 @@ module Mosquito::RateLimiter
 
   # Decrements the run counter.
   def decrement_run_count : Nil
-    metadata.decrement "run_count", by: increment_run_count_by
+    metadata.increment "run_count", by: -increment_run_count_by
   end
 
   # How much the run counter should be incremented by.


### PR DESCRIPTION
Context for this change:
1. I have a mosquito queued job that calls an API, sometimes the API call takes really short or really long to return (1 second to 3 minutes or more)
2. I use: `throttle limit: 10, per: 1.minute`. I limit 10 jobs to run per minute; if I run 11 jobs concurrently then I get a status code 429 TOO MANY REQUESTS
3. `persist_run_count` is used to persist the run count between window intervals; if the job is executed then the run count goes up, and if the job has `persist_run_count` set to `true` and succeeds, then the run count goes down, allowing more jobs to be enqueued