### PR TITLE
Updates runner to use time::span

### DIFF
--- a/src/mosquito/configuration.cr
+++ b/src/mosquito/configuration.cr
@@ -7,7 +7,7 @@ module Mosquito
 
   class Configuration
     property redis_url : String?
-    property idle_wait : Float64 = 0.1
+    property idle_wait : Time::Span = 100.milliseconds
     property successful_job_ttl : Int32 = 1
     property failed_job_ttl : Int32 = 86400
 
@@ -17,8 +17,8 @@ module Mosquito
 
     property validated = false
 
-    def idle_wait=(time_span : Time::Span)
-      @idle_wait = time_span.total_seconds
+    def idle_wait=(time_span : Float)
+      @idle_wait = time_span.seconds
     end
 
     def validate

--- a/test/mosquito/configuration_test.cr
+++ b/test/mosquito/configuration_test.cr
@@ -19,7 +19,7 @@ describe "Mosquito Config" do
     test_value = 2.4
     Mosquito.temp_config do
       Mosquito.configuration.idle_wait = test_value
-      assert_equal test_value, Mosquito.configuration.idle_wait
+      assert_equal test_value.seconds, Mosquito.configuration.idle_wait
     end
   end
 
@@ -28,7 +28,7 @@ describe "Mosquito Config" do
 
     Mosquito.temp_config do
       Mosquito.configuration.idle_wait = test_value
-      assert_equal test_value.total_seconds, Mosquito.configuration.idle_wait
+      assert_equal test_value, Mosquito.configuration.idle_wait
     end
   end
 

--- a/test/mosquito/runner/start_time_test.cr
+++ b/test/mosquito/runner/start_time_test.cr
@@ -4,10 +4,8 @@ describe "Mosquito::Runner#set_start_time" do
   let(:runner) { Mosquito::TestableRunner.new }
 
   it "logs the start time" do
-    Timecop.freeze Time.utc do
-      assert_equal 0, runner.start_time
-      runner.run :start_time
-      assert_equal Time.utc.to_unix, runner.start_time
-    end
+    assert_equal 0.seconds, runner.start_time
+    runner.run :start_time
+    refute_equal 0.seconds, runner.start_time
   end
 end


### PR DESCRIPTION
fixes #99 

Most of this patch is contributed by @jgaskins -- thank you! This is a nice modernization of the mosquito runner code without any change in affect.

related: https://github.com/waterlink/timecop.cr/issues