### PR TITLE
replaces rpoplpush in redis backend for lmove

### DIFF
--- a/src/mosquito/redis_backend.cr
+++ b/src/mosquito/redis_backend.cr
@@ -121,7 +121,7 @@ module Mosquito
     end
 
     def dequeue : JobRun?
-      if id = redis.rpoplpush waiting_q, pending_q
+      if id = redis.lmove waiting_q, pending_q, "right", "left"
         JobRun.retrieve id
       end
     end


### PR DESCRIPTION
rpoplpush is deprecated by redis as of 6.2.0. current redis version is 7.0.5

fixes #93 
blocked by https://github.com/jgaskins/redis/issues/37
blocked by #106 
