### PR TITLE
adds a better error message when a parameter type isn't supported

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-crystal 1.8.2
+crystal 1.9.2


### PR DESCRIPTION
fixes #109 

Assuming a param declaration like this: `param counts : Array(Int32)`, the compile time error message produced will look like this:

![image](https://github.com/mosquito-cr/mosquito/assets/208647/de244ba5-22a0-44fd-8102-454f34a1b6a6)

I don't think it's possible to write a test for something like this without scaffolding out a way to generate a new mosquito project and compile it. 