### PR TITLE
restores the captive thread behavior of Mosquito::Runner.start

### DIFF
--- a/demo/run.cr
+++ b/demo/run.cr
@@ -21,7 +21,7 @@ Signal::INT.trap do
   Mosquito::Runner.stop
 end
 
-Mosquito::Runner.start
+Mosquito::Runner.start(spin: false)
 
 count = 0
 while count <= 20 && Mosquito::Runner.keep_running

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -7,9 +7,13 @@ module Mosquito
     # Should mosquito continue working?
     class_property keep_running : Bool = true
 
-    def self.start
+    def self.start(spin = true)
       Log.notice { "Mosquito is buzzing..." }
       instance.run
+
+      while spin && @@keep_running
+        sleep 1
+      end
     end
 
     def self.stop


### PR DESCRIPTION
fixes #114 

@mamantoha if you have a moment to verify this works for you, I'd appreciate it.
