### PR TITLE
Provides a test backend (aka test mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Pending Release]
 ### Added
+- Adds a test backend, which can be used to inspect jobs that were enqueued and
+  the parameters they were enqueued with.
 - Job#fail now takes an optional `retry` parameter which defaults to true, allowing
   a developer to explicitly mark a job as not retry-able during a job run. Additionally
   a `should_retry` property exists which can be set as well.

--- a/src/mosquito/backend.cr
+++ b/src/mosquito/backend.cr
@@ -1,5 +1,7 @@
 module Mosquito
   abstract class Backend
+    QUEUES = %w(waiting scheduled pending dead)
+
     KEY_PREFIX = {"mosquito"}
 
     def self.named(name)
@@ -37,12 +39,23 @@ module Mosquito
 
       abstract def flush : Nil
 
+      abstract def unlock(key : String, value : String) : Nil
       abstract def lock?(key : String, value : String, ttl : Time::Span) : Bool
     end
 
     macro inherited
       extend ClassMethods
     end
+
+    def self.search_queues
+      QUEUES.first(2)
+    end
+
+    {% for q in QUEUES %}
+      def {{q.id}}_q
+        build_key {{q}}, name
+      end
+    {% end %}
 
     def store(key : String, value : Hash(String, String)) : Nil
       self.class.store key, value

--- a/src/mosquito/test_backend.cr
+++ b/src/mosquito/test_backend.cr
@@ -1,0 +1,151 @@
+module Mosquito
+  # An in-memory noop backend desigend to be used in application testing.
+  #
+  # The test mode backend simply makes a copy of job_runs at enqueue time and holds them in a class getter array.
+  #
+  # Job run id, config (aka parameters), and runtime class are kept in memory, and a truncate utility function is provided.
+  #
+  # Activate test mode configure the test backend like this:
+  #
+  # ```
+  # Mosquito.configure do |settings|
+  #   settings.backend = Mosquito::TestBackend
+  # end
+  # ```
+  #
+  # Then in your tests:
+  #
+  # ```
+  # describe "testing" do
+  #   it "enqueues the job" do
+  #     # build and enqueue a job
+  #     job_run = EchoJob.new(text: "hello world").enqueue
+  #
+  #     # assert that the job was enqueued
+  #     lastest_enqueued_job = Mosquito::TestBackend.enqueued_jobs.last
+  #
+  #     # check the job config
+  #     assert_equal "hello world", latest_enqueued_job.config["text"]
+  #
+  #     # check the job_id matches
+  #     assert_equal job_run.id, latest_enqueued_job.id
+  #
+  #     # optionally, truncate the history
+  #     Mosquito::TestBackend.flush_enqueued_jobs!
+  #   end
+  # end
+  # ```
+  class TestBackend < Mosquito::Backend
+    def self.store(key : String, value : Hash(String, String)) : Nil
+    end
+
+    def self.retrieve(key : String) : Hash(String, String)
+      {} of String => String
+    end
+
+    def self.list_queues : Array(String)
+      [] of String
+    end
+
+    def self.list_runners : Array(String)
+      [] of String
+    end
+
+    def self.delete(key : String, in ttl : Int64 = 0) : Nil
+    end
+
+    def self.delete(key : String, in ttl : Time::Span) : Nil
+    end
+
+    def self.expires_in(key : String) : Int64
+      0_i64
+    end
+
+    def self.get(key : String, field : String) : String?
+    end
+
+    def self.set(key : String, field : String, value : String) : String
+      ""
+    end
+
+    def self.increment(key : String, field : String) : Int64
+      0_i64
+    end
+
+    def self.increment(key : String, field : String, by value : Int32) : Int64
+      0_i64
+    end
+
+    def self.flush : Nil; end
+
+    def self.lock?(key : String, value : String, ttl : Time::Span) : Bool
+      false
+    end
+
+    def self.unlock(key : String, value : String) : Nil
+    end
+
+    struct EnqueuedJob
+      getter id : String
+      getter klass : Mosquito::Job.class
+      getter config : Hash(String, String)
+
+      def self.from(job_run : JobRun)
+        job_class = Mosquito::Base.job_for_type(job_run.type)
+        new(
+          job_run.id,
+          job_class,
+          job_run.config
+        )
+      end
+
+      def initialize(@id, @klass, @config)
+      end
+    end
+
+    class_property enqueued_jobs = [] of EnqueuedJob
+
+    def self.flush_enqueued_jobs!
+      @@enqueued_jobs = [] of EnqueuedJob
+    end
+
+    def enqueue(job_run : JobRun) : JobRun
+      @@enqueued_jobs << EnqueuedJob.from(job_run)
+      job_run
+    end
+
+    def dequeue : JobRun?
+      raise "Mosquito: attempted to dequeue a job from the testing backend."
+    end
+
+    def schedule(job_run : JobRun, at scheduled_time : Time) : JobRun
+      job_run
+    end
+
+    def deschedule : Array(JobRun)
+      raise "Mosquito: attempted to deschedule a job from the testing backend."
+    end
+
+    def finish(job_run : JobRun) # should this be called succeed?
+    end
+
+    def terminate(job_run : JobRun) # should this be called fail?
+    end
+
+    def flush : Nil
+    end
+
+    def size(include_dead : Bool = true) : Int64
+      0_i64
+    end
+
+    {% for name in ["waiting", "scheduled", "pending", "dead"] %}
+      def dump_{{name.id}}_q : Array(String)
+        [] of String
+      end
+    {% end %}
+
+    def scheduled_job_run_time(job_run : JobRun) : String?
+    end
+  end
+end

--- a/test/mosquito/testing_backend_test.cr
+++ b/test/mosquito/testing_backend_test.cr
@@ -1,0 +1,38 @@
+require "../test_helper"
+
+describe Mosquito::TestBackend do
+  def latest_enqueued_job
+    Mosquito::TestBackend.enqueued_jobs.last
+  end
+
+  it "holds a copy of jobs which have been enqueued" do
+    Mosquito.temp_config(backend: Mosquito::TestBackend) do
+      QueuedTestJob.new.enqueue
+      assert_equal QueuedTestJob, latest_enqueued_job.klass
+    end
+  end
+
+  it "embeds job parameters" do
+    Mosquito.temp_config(backend: Mosquito::TestBackend) do
+      EchoJob.new(text: "hello world").enqueue
+      assert_equal "hello world", latest_enqueued_job.config["text"]
+    end
+  end
+
+  it "hold the job id" do
+    Mosquito.temp_config(backend: Mosquito::TestBackend) do
+      job_run = QueuedTestJob.new.enqueue
+      assert_equal job_run.id, latest_enqueued_job.id
+    end
+  end
+
+  it "has a list of job runs which can be emptied" do
+    Mosquito.temp_config(backend: Mosquito::TestBackend) do
+      Mosquito::TestBackend.flush_enqueued_jobs!
+      job_run = EchoJob.new(text: "hello world").enqueue
+      assert_equal job_run.id, latest_enqueued_job.id
+      Mosquito::TestBackend.flush_enqueued_jobs!
+      assert Mosquito::TestBackend.enqueued_jobs.empty?
+    end
+  end
+end


### PR DESCRIPTION
fixes #43 

Two approaches were suggested in the issue:
- Run jobs synchronously.
- Catalog jobs that were enqueued, and allow the history to be checked.

The synchronous job pattern is used elsewhere and provides convenience for integration testing. A developer can then test "a user clicks this button and an email is sent to them". However it also adds code to the worker and runner -- something I try to avoid if at all possible to keep mosquito as fast as possible.

I've chosen to implement a testing backend which can be activated in the testing setup code for a project and all enqueues will simply get stored for later inspection / assertion. This avoids adding test_mode=true? checks to worker code. For situations where you need to test the affects of a job, use #run as usual.

It'll look like this:
  
  ```crystal
  Mosquito.configure do |settings|
    settings.backend = Mosquito::TestBackend
  end
  ```
  
Then in your tests:
  
  ```crystal
  describe "testing" do
    it "enqueues the job" do
      # build and enqueue a job
      job_run = EchoJob.new(text: "hello world").enqueue
  
      # assert that the job was enqueued
      lastest_enqueued_job = Mosquito::TestBackend.enqueued_jobs.last
  
      # check the job config
      assert_equal "hello world", latest_enqueued_job.config["text"]
  
      # check the job_id matches
      assert_equal job_run.id, latest_enqueued_job.id
  
      # optionally, truncate the history
      Mosquito::TestBackend.flush_enqueued_jobs!
    end
  end
  ```

This is a bare bones test helper, but I think it'll save me and other folks some headache.