### PR TITLE
Fixes distributed periodic jobs

### DIFF
--- a/src/mosquito/periodic_job_run.cr
+++ b/src/mosquito/periodic_job_run.cr
@@ -2,10 +2,26 @@ module Mosquito
   class PeriodicJobRun
     property class : Mosquito::PeriodicJob.class
     property interval : Time::Span | Time::MonthSpan
-    property last_executed_at : Time
+
+    def last_executed_at?
+      if timestamp = @metadata["last_executed_at"]?
+        Time.unix(timestamp.to_i)
+      else
+        nil
+      end
+    end
+
+    # todo add tests for this distributed tracking
+    def last_executed_at
+      last_executed_at? || Time.unix(0)
+    end
+
+    def last_executed_at=(time : Time)
+      @metadata["last_executed_at"] = time.to_unix.to_s
+    end
 
     def initialize(@class, @interval)
-      @last_executed_at = Time.unix 0
+      @metadata = Metadata.new(Backend.build_key("periodic_jobs", @class.name))
     end
 
     def try_to_execute : Bool
@@ -13,7 +29,8 @@ module Mosquito
 
       if last_executed_at + interval <= now
         execute
-        @last_executed_at = now
+
+        self.last_executed_at = now
         true
       else
         false

--- a/src/mosquito/runners/overseer.cr
+++ b/src/mosquito/runners/overseer.cr
@@ -52,7 +52,9 @@ module Mosquito::Runners
     def tick
       delta = Time.measure do
         queue_list.fetch
-        coordinator.bloop
+        run_at_most every: 1.second, label: :coordinator do
+          coordinator.bloop
+        end
         executor.dequeue_and_run_jobs
       end
 


### PR DESCRIPTION
I overlooked a small but important detail about how periodic jobs are enqueued in #108. The "last run" timestamp was stored in-process, which was fine when the coordinator was manually selected by config parameter. The bug is, when the distributed lock is enabled, all active workers will enqueue each periodic job each time the interval is up.

The fix is to store the periodic job last_run timestamp in a metadata block.

- [ ] what should the expiry on the metadata block be?
- [ ] tests for distributed enqueue of periodic jobs