### PR TITLE
dramatically decreases the time spent listing queues

### DIFF
--- a/test/mosquito/backend/queueing_test.cr
+++ b/test/mosquito/backend/queueing_test.cr
@@ -62,15 +62,6 @@ describe "Backend Queues" do
         assert_equal %w|test1 test2 test3 test4|, backend.list_queues.sort
       end
     end
-
-    it "includes queues prefixed with scheduled and waiting but not pending or dead" do
-      clean_slate do
-        fill_queues
-        fill_uncounted_queues
-
-        assert_equal %w|test1 test2 test3 test4|, backend.list_queues.sort
-      end
-    end
   end
 
   describe "schedule" do

--- a/test/mosquito/queue_test.cr
+++ b/test/mosquito/queue_test.cr
@@ -39,6 +39,13 @@ describe Queue do
   end
 
   describe "enqueue" do
+    it "adds the queue name to the list of queues" do
+      clean_slate do
+        test_queue.enqueue job_run
+        assert_includes backend.class.list_queues, test_queue.name
+      end
+    end
+
     it "can enqueue a job_run for immediate processing" do
       clean_slate do
         test_queue.enqueue job_run


### PR DESCRIPTION
One of the most frequent commands issued to the mosquito redis backend is strongly frowned upon by the redis community.

[`keys`](https://redis.io/commands/keys/) is listed as both slow and dangerous because it iterates the entire keyspace in O(n) time.

This replaces `keys` when used to enumerate the list of queues that a mosquito runner should be checking. In a redis server with 10,000 stored keys, listing search queues takes 3-5ms.

After replacing `keys` with `zadd` and `zrangeby`, listing search queues takes 0.3ms. I've chosen to use a sorted set to open up the possibility for automatically pruning the list.

This change is innocuous except in the rare case that a long list of jobs have been enqueued which need to be consumed but are no longer being enqueued. In the rare possibility that use case actually exist there are two workarounds:

- enqueue another job with a mosquito version after this commit
- manually add the queue to the list at the key `mosquito:queues`

I considered automatically falling back to the old behavior on the contingency that no queues are found but I consider the likelihood that someone is using mosquito in a manner that would require this mitigation is tiny. The amount of effort required to mitigate the problem is small, and the amount of effort required to maintain the old behavior on some sort of fallback is significant.