### PR TITLE
provides for multiple executors operating under a single runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@
 
 <img src="https://mosquito-cr.github.io/images/amber-mosquito-small.png" align="right">
 
-Mosquito is a generic background job runner written primarily for Crystal. Significant inspiration from experience with the successes and failings many Ruby gems in this vein.
+Mosquito is a generic background job runner written primarily for Crystal. Significant inspiration from experience with the successes and failings many Ruby gems in this vein. Once compiled, a mosquito binary can start work in about 10 milliseconds.
 
 Mosquito currently provides these features:
-- Delayed execution
-- Scheduled / Periodic execution
+
+- Delayed execution (`SendEmailJob.new(email: :welcome, address: user.email).enqueue(in: 3.minutes)`)
+- Scheduled / Periodic execution (`RunEveryHourJob.new`)
 - Job Storage in Redis
 - Automatic rescheduling of failed jobs
-- Progressively increasing delay of failed jobs
+- Progressively increasing delay of rescheduled failed jobs
 - Dead letter queue of jobs which have failed too many times
 - Rate limited jobs
 

--- a/src/mosquito/configuration.cr
+++ b/src/mosquito/configuration.cr
@@ -13,8 +13,8 @@ module Mosquito
     property failed_job_ttl : Int32 = 86400
 
     @[Deprecated("cron scheduling can now handled automatically. See https://github.com/mosquito-cr/mosquito/pull/108")]
-    property run_cron_scheduler : Bool = true
-    property use_distributed_lock : Bool = false
+    property run_cron_scheduler : Bool = false
+    property use_distributed_lock : Bool = true
 
     property run_from : Array(String) = [] of String
     property backend : Mosquito::Backend.class = Mosquito::RedisBackend

--- a/src/mosquito/periodic_job_run.cr
+++ b/src/mosquito/periodic_job_run.cr
@@ -49,6 +49,9 @@ module Mosquito
       if last_executed_at + interval <= now
         execute
 
+        # Weaknesses:
+        # - If something interferes with the job run, it won't be correct that it was executed.
+        # - if the worker is backlogged, the start time will be different from the last executed time.
         self.last_executed_at = now
         true
       else

--- a/src/mosquito/queue.cr
+++ b/src/mosquito/queue.cr
@@ -79,6 +79,8 @@ module Mosquito
     getter? empty : Bool
     property backend : Mosquito::Backend
 
+    Log = ::Log.for self
+
     def initialize(@name : String)
       @empty = false
       @backend = Mosquito.backend.named name
@@ -86,6 +88,7 @@ module Mosquito
     end
 
     def enqueue(job_run : JobRun) : JobRun
+      Log.trace { "Enqueuing #{job_run} for immediate execution" }
       backend.enqueue job_run
     end
 
@@ -94,6 +97,7 @@ module Mosquito
     end
 
     def enqueue(job_run : JobRun, at execute_time : Time) : JobRun
+      Log.trace { "Enqueuing #{job_run} at #{execute_time}" }
       backend.schedule job_run, execute_time
     end
 

--- a/src/mosquito/runnable.cr
+++ b/src/mosquito/runnable.cr
@@ -1,0 +1,176 @@
+module Mosquito
+  # Runnable implements a general purpose spawn/loop which carries a state
+  # enum.
+  #
+  # ## Managing a Runnable
+  #
+  # The primary purpose of Runnable is to cleanly abstract the details of
+  # spawning a thread, running a loop, and shutting down when asked.
+  #
+  # A service which manages a Runnable might look like this:
+  #
+  # ```crystal
+  # runnable = MyRunnable.new
+  #
+  # # This will spawn and return immediately.
+  # runnable.start
+  #
+  # puts runnable.state # => State::Working
+  #
+  # # Some time later...
+  # should_be_stopped = runnable.stop has_stopped =
+  # should_be_stopped.receive
+  # ```
+  #
+  #
+  # ## Implementing a Runnable
+  #
+  # A runnable implementation needs to implement only two methods: #each_run
+  # and #runnable_name. In addition, pre_run and post_run are available for
+  # setup and teardown.
+  #
+  # Runnable state is managed automatically through startup and shutdown, but
+  # within each_run it can be manually altered with `#state=`.
+  #
+  # ### Example
+  #
+  # ```crystal
+  # class MyRunnable
+  #   include Mosquito::Runnable
+  #
+  #   # Optional
+  #   def pre_run
+  #     puts "my runnable is starting"
+  #   end
+  #
+  #   def each_run
+  #     puts "my runnable is running"
+  #   end
+  #
+  #   # Optional
+  #   def post_run
+  #     puts "my runnable has stopped"
+  #   end
+  #
+  #   def runnable_name
+  #     "MyRunnable"
+  #   end
+  # end
+  # ```
+  #
+  # Implementation details about what work should be done in the spawned fiber
+  # are placed in #each_run.
+  #
+  module Runnable
+    enum State
+      Starting
+      Working
+      Idle
+      Stopping
+      Finished
+
+      def running?
+        starting? || working? || idle?
+      end
+
+      # ie, not starting
+      def started?
+        working? || idle?
+      end
+    end
+
+    # Tracks the state of this runnable.
+    #
+    # Initially it will be `State::Starting`. After `#run` is called it will
+    # be `State::Working`.
+    #
+    # When `#stop` is called it will be `State::Stopping`. After `#run` finishes,
+    # it will be `State::Finished`.
+    #
+    # It is not necessary to set this manually, but it's available to an implementation
+    # if needed. See `Mosquito::Runners::Executor#state=` (source code) for an example.
+    getter state : State = State::Starting
+
+    # After #run has been called this holds a reference to the Fiber
+    # which is used to check that the fiber is still running.
+    getter fiber : Fiber?
+
+    getter my_name : String {
+      "#{self.class.name.underscore.gsub("::", ".")}.#{self.object_id}"
+    }
+
+    private def state=(state : State)
+      @state = state
+    end
+
+    def dead? : Bool
+      if fiber_ = fiber
+        fiber_.dead?
+      else
+        false
+      end
+    end
+
+    # Start the Runnable, and capture the fiber to a property.
+    #
+    # The spawned fiber will not return as long as state.running?.
+    #
+    # State can be altered internally or externally to cause it to exit
+    # but the cleanest way to do that is to call #stop.
+    def run
+      @fiber = spawn(name: my_name) do
+        log = Log.for(my_name)
+        log.info { runnable_name + " is starting" }
+
+        self.state = State::Working
+        pre_run
+
+        while state.running?
+          each_run
+        end
+
+        post_run
+        self.state = State::Finished
+      end
+    end
+
+    # Request that the next time the run loop cycles it should exit instead.
+    # The runnable doesn't exit immediately so #stop returns a notification
+    # channel.
+    #
+    # #stop spawns a fiber which monitors the state and sends a bool in two
+    # circumstances.  It will stop waiting for the spawn to exit at 25 seconds.
+    # If the spawn has actually stopped the notification channel will broadcast
+    # a true, otherwise false.
+    def stop : Channel(Bool) self.state = State::Stopping if state.running?
+      notifier = Channel(Bool).new
+
+      spawn do
+        start = Time.utc
+        while state.stopping? && (Time.utc - start) < 25.seconds
+          Fiber.yield
+        end
+        notifier.send state.finished?
+
+        Log.info { runnable_name + " has stopped" }
+      end
+
+      notifier
+    end
+
+    # Used to print a pretty name for logging.
+    abstract def runnable_name : String
+
+    # Implementation of what this Runnable should do on each cycle.
+    #
+    # Take care that @state is #running? at the end of the method
+    # unless it is finished and should exit.
+    abstract def each_run : Nil
+
+    # Available to hook a one time setup before the run loop.
+    def pre_run : Nil ; end
+
+    # Available to hook any teardown logic after the run loop.
+    def post_run : Nil ; end
+  end
+end

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -1,50 +1,88 @@
 require "colorize"
 
 module Mosquito
+  # This singleton class serves as a shorthand for starting and managing an Overseer.
+  #
+  # A minimal usage of Mosquito::Runner is:
+  #
+  # ```
+  # require "mosquito"
+  #
+  # # When the process receives sigint, it'll notify the overseer to shut down gracefully.
+  # trap("INT") do
+  #   Mosquito::Runner.stop(wait: true)
+  # end
+  #
+  # # Starts the overseer, and holds the thread captive.
+  # Mosquito::Runner.start
+  # ```
+  #
+  # If for some reason you want to manage an overseer or group of overseers yourself, Mosquito::Runner can be omitted entirely:
+  #
+  # ```crystal
+  # require "mosquito"
+  #
+  # mosquito = Mosquito::Overseer.new
+  #
+  # # Spawns a mosquito managed fiber and returns immediately
+  # mosquito.run
+  #
+  # trap "INT" do
+  #   mosquito.stop.receive
+  # end
+  # ```
   class Runner
     Log = ::Log.for self
-
-    # Should mosquito continue working?
-    class_property keep_running : Bool = true
 
     # Start the mosquito runner.
     #
     # If spin = true (default) the function will not return until the runner is
     # shut down.  Otherwise it will return immediately.
     #
-    def self.start(spin = true) Log.notice { "Mosquito is buzzing..." }
+    def self.start(spin = true)
+      Log.notice { "Mosquito is buzzing..." }
       instance.run
 
-      while spin && @@keep_running
-        sleep 1
+      while spin && keep_running
+        Fiber.yield
       end
+    end
+
+    # :nodoc:
+    def self.keep_running : Bool
+      instance.state.starting? || instance.state.running?
     end
 
     # Request the mosquito runner stop. The runner will not abort the current job
     # but it will not start any new jobs.
-    def self.stop
+    #
+    # See `Mosquito::Runnable#stop`.
+    def self.stop(wait = false)
       Log.notice { "Mosquito is shutting down..." }
-      self.keep_running = false
-      instance.stop
+      finished_notifier = instance.stop
+
+      if wait
+        finished_notifier.receive
+      end
     end
 
     private def self.instance : self
       @@instance ||= new
     end
 
+    # :nodoc:
+    delegate run, stop, state, to: @overseer
+
+    # :nodoc:
+    delegate running?, to: @overseer.state
+
+    # :nodoc:
+    getter overseer : Runners::Overseer
+
+    # :nodoc:
     def initialize
       Mosquito.configuration.validate
       @overseer = Runners::Overseer.new
-    end
-
-    def run
-      spawn do
-        @overseer.run
-      end
-    end
-
-    def stop
-      @overseer.stop
     end
   end
 end

--- a/src/mosquito/runners/executor.cr
+++ b/src/mosquito/runners/executor.cr
@@ -1,14 +1,31 @@
+require "./run_at_most"
+require "../runnable"
+
 module Mosquito::Runners
-  # An Executor is responsible for building Job classes with deserialized
-  # parameters and calling #run on them. It measures the time it takes to
-  # run a job and provides detailed log messages about the current status.
+  # The executor is the center of work in Mosquito, and it's is the demarcation
+  # point between Mosquito framework and application code. Above the Executor
+  # is entirely Mosquito, and below it is application code.
   #
-  # Executor#deqeue_and_run_jobs is the entrypoint and shoud be treated as
-  # if it will return only after a relative eternity.
+  # An Executor is responsible for hydrating Job classes with deserialized
+  # parameters and calling `Mosquito::Job#run` on them. It measures the time it
+  # takes to run a job and provides detailed log messages about the current
+  # status.
+  #
+  # An executor is a `Mosquito::Runnable` and should be interacted with according to
+  # the Runnable API.
+  #
+  # To build an executor, provide a job input channel and an idle bell channel. These
+  # channels can be shared between all available executors.
+  #
+  # The executor will ring the idle bell when it is ready to accept work and then wait
+  # for work to show up on the job pipeline. After the job is finished it will ring the
+  # bell again and wait for more work.
   class Executor
     include RunAtMost
+    include Runnable
 
     Log = ::Log.for self
+    getter log : ::Log
 
     # How long a job config is persisted after success
     property successful_job_ttl : Int32 { Mosquito.configuration.successful_job_ttl }
@@ -16,29 +33,64 @@ module Mosquito::Runners
     # How long a job config is persisted after failure
     property failed_job_ttl : Int32 { Mosquito.configuration.failed_job_ttl }
 
-    getter queue_list : QueueList
+    # Where work is received from the overseer.
+    getter job_pipeline : Channel(Tuple(JobRun, Queue))
 
-    def initialize(@queue_list)
-    end
+    # Used to notify the overseer that this executor is idle.
+    getter idle_bell : Channel(Bool)
 
-    def dequeue_and_run_jobs
-      queue_list.each do |q|
-        run_next_job q
+    private def state=(state : State)
+      # Send a message to the overseer that this executor is idle.
+      if state == State::Idle
+        spawn { idle_bell.send true }
       end
+
+      super
     end
 
-    def run_next_job(q : Queue)
-      job_run = q.dequeue
-      return unless job_run
+    def initialize(@job_pipeline, @idle_bell)
+      @log = Log.for(object_id.to_s)
+    end
 
-      Log.notice { "#{"Starting:".colorize.magenta} #{job_run} from #{q.name}" }
+    # :nodoc:
+    def runnable_name : String
+      "Executor<#{object_id}>"
+    end
+
+    # :nodoc:
+    def pre_run : Nil
+      # Overseer won't try to dequeue and send any jobs unless it
+      # knows that an executor is idle, so the first thing to do
+      # is mark this executor as idle. See #state=.
+      self.state = State::Idle
+    end
+
+    # :nodoc:
+    def each_run : Nil
+      dequeue = job_pipeline.receive?
+      return if dequeue.nil?
+
+      self.state = State::Working
+      job_run, queue = dequeue
+      log.trace { "Dequeued #{job_run} from #{queue.name}" }
+      execute job_run, queue
+      log.trace { "Finished #{job_run} from #{queue.name}" }
+      self.state = State::Idle
+    end
+
+    # Runs a job from a Queue.
+    #
+    # Execution time is measured and logged, and the job is either forgotten
+    # or, if it fails, rescheduled.
+    def execute(job_run : JobRun, from_queue q : Queue)
+      log.info { "#{"Starting:".colorize.magenta} #{job_run} from #{q.name}" }
 
       duration = Time.measure do
         job_run.run
       end.total_seconds
 
       if job_run.succeeded?
-        Log.notice { "#{"Success:".colorize.green} #{job_run} finished and took #{time_with_units duration}" }
+        log.info { "#{"Success:".colorize.green} #{job_run} finished and took #{time_with_units duration}" }
         q.forget job_run
         job_run.delete in: successful_job_ttl
 
@@ -60,17 +112,18 @@ module Mosquito::Runners
           message << " (at "
           message << next_execution
           message << ")"
+          log.warn { message.to_s }
         else
           q.banish job_run
           job_run.delete in: failed_job_ttl
 
           message << "cannot be rescheduled".colorize.yellow
+          log.error { message.to_s }
         end
-
-        Log.warn { message.to_s }
       end
     end
 
+    # :nodoc:
     def time_with_units(seconds : Float64)
       if seconds > 0.1
         "#{(seconds).*(100).trunc./(100)}s".colorize.red

--- a/src/mosquito/runners/idle_wait.cr
+++ b/src/mosquito/runners/idle_wait.cr
@@ -1,0 +1,14 @@
+module Mosquito::Runners
+  module IdleWait
+    def with_idle_wait(idle_wait : Time::Span)
+      delta = Time.measure do
+        yield
+      end
+
+      if delta < idle_wait
+        # Fiber.timeout(idle_wait - delta)
+        sleep(idle_wait - delta)
+      end
+    end
+  end
+end

--- a/src/mosquito/runners/overseer.cr
+++ b/src/mosquito/runners/overseer.cr
@@ -1,3 +1,8 @@
+require "./idle_wait"
+require "./queue_list"
+require "./run_at_most"
+require "../runnable"
+
 module Mosquito::Runners
   # The Overseer is responsible for managing:
   # - a `Coordinator`
@@ -7,59 +12,171 @@ module Mosquito::Runners
   #
   # An overseer manages the loop that each thread or process runs.
   class Overseer
+    include IdleWait
     include RunAtMost
+    include Runnable
 
     Log = ::Log.for self
 
-    # Minimum time in seconds to wait between checking for jobs.
-    property idle_wait : Time::Span {
+    getter queue_list : QueueList
+    getter executors
+    getter coordinator
+
+    # The channel where job runs which have been dequeued are sent to executors.
+    getter work_handout
+
+    # When an executor transitions to idle it will send a True here. The Overseer
+    # uses this as a signal to check the queues for more work.
+    getter idle_notifier
+
+    # The number of executors to start.
+    getter executor_count = 3
+
+    getter idle_wait : Time::Span {
       Mosquito.configuration.idle_wait
     }
 
-    property keep_running : Bool
-
-    getter queue_list, executor, coordinator
-
     def initialize
+      @idle_notifier = Channel(Bool).new
+
       @queue_list = QueueList.new
       @coordinator = Coordinator.new queue_list
-      @executor = Executor.new queue_list
+      @executors = [] of Executor
+      @work_handout = Channel(Tuple(JobRun, Queue)).new
 
-      @keep_running = true
+      executor_count.times do
+        @executors << build_executor
+      end
     end
 
-    def worker_id
-      "Worker [#{coordinator.instance_id}]"
+    def build_executor : Executor
+      Executor.new(work_handout, idle_notifier)
     end
 
-    def stop
-      Log.info { worker_id + " is done after this job." }
-      @keep_running = false
+    def runnable_name : String
+      "Overseer<#{object_id}>"
     end
 
-    # Runs the overseer workflow.
-    # Infinite loop.
-    def run
-      Log.info { worker_id + " clocking in." }
+    def sleep
+      Log.trace { "Going to sleep now for #{idle_wait}" }
+      sleep idle_wait
+    end
 
-      while keep_running
-        tick
+    # Starts all the subprocesses.
+    def pre_run : Nil
+      Log.info { "Starting #{@executors.size} executors." }
+      @queue_list.run
+      @executors.each(&.run)
+    end
+
+    # Notify all subprocesses to stop, and wait until they do.
+    def post_run : Nil
+      Log.info { "Stopping #{@executors.size} executors." }
+      stopped_notifiers = executors.map do |executor|
+        executor.stop
+      end
+      work_handout.close
+      stopped_notifiers.each(&.receive)
+      Log.info { "All executors stopped." }
+    end
+
+    # The goal for the overseer is to:
+    # - Ensure that the coordinator gets run frequently to schedule delayed/periodic jobs.
+    # - Wait for an executor to be idle, and dequeue work if possible.
+    # - Monitor the executor pool for unexpected termination and respawn.
+    def each_run : Nil
+      coordinator.schedule
+
+      # I cannot imagine a situation where this happens in the normal flow of
+      # events, but if it did it would be a mess. If something crashes hard
+      # enough that one of these channels closes the whole thing is going to
+      # come crashing down and we should just quit now.
+      if work_handout.closed? || idle_notifier.closed?
+        Log.fatal { "Executor communication channels closed, overseer will stop." }
+        stop
+        return
       end
 
-      Log.info { worker_id + " finished for now." }
+      # If the queue list hasn't run at least once, it won't have any queues to
+      # search for so we'll just defer until it's available.
+      unless queue_list.state.started?
+        Log.debug { "Waiting for the queue list to fetch possible queues" }
+        return
+      end
+
+
+      Log.trace { "Waiting for an idle executor" }
+      all_executors_busy = true
+
+      # This feature is under documented in the crystal manual.
+      # This will attempt to receive from a the idle notifier, but only
+      # wait for up to idle_wait seconds.
+      #
+      # The interrupt is necessary to remind the coordinator to schedule
+      # jobs.
+      select
+      when @idle_notifier.receive
+        Log.trace { "Found an idle executor" }
+        all_executors_busy = false
+      when timeout(idle_wait)
+      end
+
+      case
+      # If none of the executors is idle, don't dequeue anything or it'll get lost.
+      when all_executors_busy
+        Log.trace { "No idle executors" }
+
+      # We know that an executor is idle and will take the work, it's safe to dequeue.
+      when next_job_run = dequeue_job?
+        job_run, queue = next_job_run
+        Log.trace { "Dequeued job: #{job_run.id} #{queue.name}" }
+        work_handout.send next_job_run
+
+      # An executor is idle, but dequeue returned nil.
+      else
+        Log.trace { "No job to dequeue" }
+        sleep
+
+        # The idle notification has been consumed, and it needs to be
+        # re-sent so that the next loop can still find the idle executor.
+        spawn { @idle_notifier.send true }
+      end
+
+      check_for_deceased_runners
     end
 
-    def tick
-      delta = Time.measure do
-        queue_list.fetch
-        run_at_most every: 1.second, label: :coordinator do
-          coordinator.bloop
+    # Weaknesses: This implementation sometimes starves queues because it doesn't
+    # round robin, prioritize queues, or anything else.
+    def dequeue_job? : Tuple(JobRun, Queue)?
+      queue_list.each do |q|
+        if job_run = q.dequeue
+          return { job_run, q }
         end
-        executor.dequeue_and_run_jobs
+      end
+    end
+
+    # If an executor dies, it's probably because a bug exists somewhere in Mosquito itself.
+    #
+    # When a job fails any exceptions are caught and logged. If a job causes something more
+    # catastrophic we can try to recover by spawning a new executor.
+    def check_for_deceased_runners : Nil
+      executors.select{|e| e.state.started?}.select(&.dead?).each do |dead_executor|
+        Log.fatal do
+          <<-MSG
+            Executor #{dead_executor.runnable_name} died.
+            A new executor will be started.
+          MSG
+        end
+        executors.delete dead_executor
       end
 
-      if delta < idle_wait
-        sleep(idle_wait - delta)
+      (executor_count - executors.size).times do
+        executors << build_executor.tap(&.run)
+      end
+
+      if queue_list.dead?
+        Log.fatal { "QueueList has died, overseer will stop." }
+        stop
       end
     end
   end

--- a/test/helpers/logging_helper.cr
+++ b/test/helpers/logging_helper.cr
@@ -1,3 +1,5 @@
+require "log"
+
 class TestingLogBackend < Log::MemoryBackend
   def self.instance
     @@instance ||= new
@@ -42,4 +44,8 @@ class Minitest::Test
   end
 end
 
-Log.builder.bind "*", :debug, TestingLogBackend.instance
+Log.setup do |config|
+  config.bind "*", :debug, TestingLogBackend.instance
+  config.bind "redis.*", :warn, TestingLogBackend.instance
+  config.bind "mosquito.*", :trace, TestingLogBackend.instance
+end

--- a/test/helpers/mock_coordinator.cr
+++ b/test/helpers/mock_coordinator.cr
@@ -1,4 +1,12 @@
 class MockCoordinator < Mosquito::Runners::Coordinator
+  getter schedule_count
+
+  def initialize(queue_list : Mosquito::Runners::QueueList)
+    super
+
+    @schedule_count = 0
+  end
+
   def only_if_coordinator : Nil
     if @always_coordinator
       yield
@@ -13,5 +21,10 @@ class MockCoordinator < Mosquito::Runners::Coordinator
 
   def always_coordinator!(always = true)
     @always_coordinator = always
+  end
+
+  def schedule
+    @schedule_count += 1
+    super
   end
 end

--- a/test/helpers/mock_executor.cr
+++ b/test/helpers/mock_executor.cr
@@ -1,2 +1,24 @@
 class MockExecutor < Mosquito::Runners::Executor
+  def state=(state : Mosquito::Runnable::State)
+    super
+  end
+
+  def run
+    self.state = Mosquito::Runnable::State::Working
+  end
+
+  def stop
+    self.state = Mosquito::Runnable::State::Stopping
+    Channel(Bool).new.tap do |notifier|
+      spawn {
+        self.state = Mosquito::Runnable::State::Finished
+        notifier.send true
+      }
+    end
+  end
+
+  def receive_job
+    job_run, queue = job_pipeline.receive
+    job_run
+  end
 end

--- a/test/helpers/mock_overseer.cr
+++ b/test/helpers/mock_overseer.cr
@@ -1,3 +1,3 @@
 class MockOverseer < Mosquito::Runners::Overseer
-  property queue_list, coordinator, executor
+  property queue_list, coordinator, executors, work_handout, idle_notifier
 end

--- a/test/helpers/mock_queue_list.cr
+++ b/test/helpers/mock_queue_list.cr
@@ -1,3 +1,4 @@
 class MockQueueList < Mosquito::Runners::QueueList
-  getter :queues
+  getter queues
+  setter state
 end

--- a/test/mosquito/queued_job_test.cr
+++ b/test/mosquito/queued_job_test.cr
@@ -36,7 +36,7 @@ describe Mosquito::QueuedJob do
     it "can be passed in" do
       clear_logs
       EchoJob.new("quack").perform
-      assert_includes logs, "quack"
+      assert_logs_match "quack"
     end
 
     it "can have a boolean false passed as a parameter (and it's not assumed to be a nil)" do

--- a/test/mosquito/runnable_test.cr
+++ b/test/mosquito/runnable_test.cr
@@ -1,0 +1,66 @@
+class Namespace::ConcreteRunnable
+  include Mosquito::Runnable
+
+  getter first_run_notifier = Channel(Bool).new
+  getter first_run = true
+  property state : Mosquito::Runnable::State
+
+  # Testing wedge which calls: run, waits for a run to happen, and then calls stop.
+  def test_run : Nil
+    run
+    first_run_notifier.receive
+    stop.receive
+  end
+
+  def runnable_name : String
+    "concrete_runnable"
+  end
+
+  def each_run : Nil
+    if first_run
+      @first_run = false
+      first_run_notifier.send true
+    end
+    Fiber.yield
+  end
+
+  def stop
+    first_run_notifier.close
+    super
+  end
+end
+
+describe Mosquito::Runnable do
+  let(:runnable) { Namespace::ConcreteRunnable.new }
+
+  it "builds a my_name" do
+    assert_equal "namespace.concrete_runnable.#{runnable.object_id}", runnable.my_name
+  end
+
+  describe "run" do
+    it "should log a startup message" do
+      clear_logs
+      runnable.test_run
+      assert_logs_match "concrete_runnable is starting"
+    end
+
+    it "should log a finished message" do
+      clear_logs
+      runnable.test_run
+      assert_logs_match "concrete_runnable has stopped"
+    end
+  end
+
+  describe "stop" do
+    it "should set the stopping flag" do
+      runnable.state = Mosquito::Runnable::State::Working
+      notifier = runnable.stop
+      assert_equal Mosquito::Runnable::State::Stopping, runnable.state
+    end
+
+    it "should set the finished flag" do
+      runnable.test_run
+      assert_equal Mosquito::Runnable::State::Finished, runnable.state
+    end
+  end
+end

--- a/test/mosquito/runners/overseer_test.cr
+++ b/test/mosquito/runners/overseer_test.cr
@@ -1,69 +1,107 @@
 require "../../test_helper"
 
 describe "Mosquito::Runners::Overseer" do
+  getter(executor_pipeline) { Channel(Tuple(JobRun, Queue)).new }
+  getter(idle_notifier) { Channel(Bool).new }
   getter(queue_list) { MockQueueList.new }
   getter(coordinator) { MockCoordinator.new queue_list }
-  getter(executor) { MockExecutor.new queue_list }
+  getter(executor) { MockExecutor.new executor_pipeline, idle_notifier }
 
   getter(overseer : MockOverseer) {
     MockOverseer.new.tap do |o|
       o.queue_list = queue_list
       o.coordinator = coordinator
-      o.executor = executor
+      o.idle_notifier = idle_notifier
+      o.executors = [] of Mosquito::Runners::Executor
+      o.executor_count.times do
+        o.executors << executor.as(Mosquito::Runners::Executor)
+      end
     end
   }
 
-  describe "tick" do
-    it "waits the proper amount of time between cycles" do
+  def register(job_class : Mosquito::Job.class)
+    Mosquito::Base.register_job_mapping job_class.name.underscore, job_class
+    queue_list.queues << job_class.queue
+  end
+
+  def run_job(job_class : Mosquito::Job.class)
+    register job_class
+    job_class.reset_performance_counter!
+    job_run = job_class.new.enqueue
+    executor.execute job_run, from_queue: job_class.queue
+  end
+
+  describe "pre_run" do
+    it "runs all executors" do
+      overseer.executors.each do |executor|
+        assert_equal Runnable::State::Starting, executor.state
+      end
+      overseer.pre_run
+      overseer.executors.each do |executor|
+        assert_equal Runnable::State::Working, executor.state
+      end
+    end
+  end
+
+  describe "post_run" do
+    it "stops all executors" do
+      overseer.executors.each(&.run)
+      overseer.post_run
+      overseer.executors.each do |executor|
+        assert_equal Runnable::State::Finished, executor.state
+      end
+    end
+
+    it "logs messages about stopping the executors" do
+      clear_logs
+      overseer.pre_run
+      overseer.post_run
+      assert_logs_match "Stopping #{overseer.executor_count} executors."
+      assert_logs_match "All executors stopped."
+    end
+  end
+
+  describe "each_run" do
+    it "dequeues a job and dispatches it to the pipeline" do
       clean_slate do
+        register QueuedTestJob
+        expected_job_run = QueuedTestJob.new.enqueue
+
+        overseer.work_handout = Channel(Tuple(JobRun, Queue)).new
+
+        queue_list.state = Runnable::State::Working
+        executor.state = Runnable::State::Idle
+
+        # each_run will block until there's a receiver on the channel
+        spawn { overseer.each_run }
+        actual_job_run, queue = overseer.work_handout.receive
+        assert_equal expected_job_run, actual_job_run
+        assert_equal QueuedTestJob.queue, queue
+      end
+    end
+
+    it "waits #idle_wait before checking the queue again" do
+      clean_slate do
+        # an idle executor, but no jobs in the queue
+        executor.state = Runnable::State::Idle
+        queue_list.state = Runnable::State::Working
+
         tick_time = Time.measure do
-          overseer.tick
+          overseer.each_run
         end
 
         assert_in_epsilon(
           overseer.idle_wait.total_seconds,
           tick_time.total_seconds,
-          epsilon: 0.02
+          epsilon: 0.05
         )
       end
     end
-  end
 
-  describe "run" do
-    it "should log a startup message" do
-      overseer.keep_running = false
-      clear_logs
-      overseer.run
-      assert_logs_match "clocking in."
-    end
-
-    it "should log a finished message" do
-      overseer.keep_running = false
-      clear_logs
-      overseer.run
-      assert_logs_match "finished for now"
-    end
-  end
-
-  describe "stop" do
-    it "should log a stop message" do
-      clear_logs
-      overseer.stop
-      assert_logs_match "is done after this job."
-    end
-
-    it "should set the stop flag" do
-      overseer.stop
-      assert_equal false, overseer.keep_running
-    end
-  end
-
-  describe "worker_id" do
-    it "should return a unique id" do
-      one = Mosquito::Runners::Overseer.new
-      two = Mosquito::Runners::Overseer.new
-
-      refute_equal one.worker_id, two.worker_id
+    it "triggers the scheduler" do
+      assert_equal 0, coordinator.schedule_count
+      overseer.each_run
+      assert_equal 1, coordinator.schedule_count
     end
   end
 end

--- a/test/mosquito/runners/queue_list_test.cr
+++ b/test/mosquito/runners/queue_list_test.cr
@@ -9,20 +9,21 @@ describe "Mosquito::Runners::QueueList" do
     EchoJob.new(text: "hello world").enqueue
   end
 
-  describe "fetch" do
+  describe "each_run" do
     it "returns a list of queues" do
       clean_slate do
         enqueue_jobs
-        queue_list.fetch
+        queue_list.each_run
         assert_equal ["failing_job", "io_queue", "passing_job"], queue_list.queues.map(&.name).sort
       end
     end
 
     it "logs a message about the number of fetched queues" do
       clean_slate do
+        clear_logs
         enqueue_jobs
-        queue_list.fetch
-        assert_logs_match "found 3 queues"
+        queue_list.each_run
+        assert_logs_match "found 3 new queues"
       end
     end
   end
@@ -33,7 +34,7 @@ describe "Mosquito::Runners::QueueList" do
         enqueue_jobs
 
         Mosquito.temp_config(run_from: ["io_queue", "passing_job"]) do
-          queue_list.fetch
+          queue_list.each_run
         end
       end
 
@@ -45,7 +46,7 @@ describe "Mosquito::Runners::QueueList" do
         enqueue_jobs
 
         Mosquito.temp_config(run_from: ["test4"]) do
-          queue_list.fetch
+          queue_list.each_run
         end
 
         assert_logs_match "No watchable queues found."
@@ -54,7 +55,7 @@ describe "Mosquito::Runners::QueueList" do
 
     it "doesnt log an error when no queues are present" do
       clean_slate do
-        queue_list.fetch
+        queue_list.each_run
         refute_logs_match "No watchable queues found."
       end
     end


### PR DESCRIPTION
This will fix #122  #18 and #80

My goal here is to minimally make mosquito network bound workloads significantly faster. Testing with @mamantoha shards.info codebase it’s trivial to cut the scrape time for the whole run by 60-70% because the whole workload is network bound. CPU abound workloads will have almost no benefit here, but the framework is laid for multi process work in the future. 

As always, comments welcome and appreciated. 