### PR TITLE
zrange redis command fix + more permissive redis shard version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -18,7 +18,7 @@ targets:
 dependencies:
   redis:
     github: jgaskins/redis
-    version: ~> 0.7.0
+    version: ~> 0.7
 
 development_dependencies:
   minitest:

--- a/src/mosquito/redis_backend.cr
+++ b/src/mosquito/redis_backend.cr
@@ -122,7 +122,7 @@ module Mosquito
 
     def self.list_queues : Array(String)
       key = build_key(LIST_OF_QUEUES_KEY)
-      list_queues = redis.zrange(key, 0, -1).as(Array)
+      list_queues = redis.zrange(key, "0", "-1").as(Array)
 
       return [] of String unless list_queues.any?
 
@@ -221,7 +221,7 @@ module Mosquito
         if type == "list"
           redis.lrange(key, "0", "-1").as(Array(Redis::Value)).map(&.as(String))
         elsif type == "zset"
-          redis.zrange(key, 0, -1).as(Array(Redis::Value)).map(&.as(String))
+          redis.zrange(key, "0", "-1").as(Array(Redis::Value)).map(&.as(String))
         elsif type == "none"
           [] of String
         else


### PR DESCRIPTION
The redis shard version requirements of https://github.com/defense-cr/defense conflicts with the requirements of the mosquito shard. 

While trying the tests with the last redis shard version 0.8.0, the new changes in https://github.com/jgaskins/redis/commit/70266be498b1d448594b5ab2eb098600dd70dbb8 triggered failures.

I've included a suggested fix with this PR. 

Feel free to modify / comment for a better solution.