### PR TITLE
sleeps the Mosquito::Runner with `sleep 1` instead of `Fiber.yield`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       REDIS_URL: redis://redis:6379/1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: crystal-lang/install-crystal@v1
       with:
         crystal: ${{matrix.crystal_version}}

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -44,7 +44,7 @@ module Mosquito
       instance.run
 
       while spin && keep_running
-        Fiber.yield
+        sleep 1
       end
     end
 


### PR DESCRIPTION
Fixes #126
cf https://github.com/crystal-lang/crystal/issues/9128