### PR TITLE
add ability to configure global Redis namespace prefix

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-crystal 1.11.2
+crystal 1.9.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-crystal 1.9.2
+crystal 1.11.2

--- a/src/mosquito/backend.cr
+++ b/src/mosquito/backend.cr
@@ -9,11 +9,7 @@ module Mosquito
     end
 
     def self.build_key(*parts)
-      if global_prefix = Mosquito.configuration.global_prefix
-        KeyBuilder.build global_prefix, KEY_PREFIX, *parts
-      else
-        KeyBuilder.build KEY_PREFIX, *parts
-      end
+      KeyBuilder.build Mosquito.configuration.global_prefix, KEY_PREFIX, *parts
     end
 
     def build_key(*parts)

--- a/src/mosquito/backend.cr
+++ b/src/mosquito/backend.cr
@@ -9,7 +9,11 @@ module Mosquito
     end
 
     def self.build_key(*parts)
-      KeyBuilder.build KEY_PREFIX, *parts
+      if global_prefix = Mosquito.configuration.global_prefix
+        KeyBuilder.build global_prefix, KEY_PREFIX, *parts
+      else
+        KeyBuilder.build KEY_PREFIX, *parts
+      end
     end
 
     def build_key(*parts)
@@ -78,7 +82,7 @@ module Mosquito
     abstract def dequeue : JobRun?
     abstract def schedule(job_run : JobRun, at scheduled_time : Time) : JobRun
     abstract def deschedule : Array(JobRun)
-    abstract def finish(job_run : JobRun) # should this be called succeed?
+    abstract def finish(job_run : JobRun)    # should this be called succeed?
     abstract def terminate(job_run : JobRun) # should this be called fail?
     abstract def flush : Nil
     abstract def size(include_dead : Bool = true) : Int64
@@ -88,6 +92,5 @@ module Mosquito
     {% end %}
 
     abstract def scheduled_job_run_time(job_run : JobRun) : String?
-
   end
 end

--- a/src/mosquito/configuration.cr
+++ b/src/mosquito/configuration.cr
@@ -17,6 +17,7 @@ module Mosquito
     property use_distributed_lock : Bool = true
 
     property run_from : Array(String) = [] of String
+    property global_prefix : String? = nil
     property backend : Mosquito::Backend.class = Mosquito::RedisBackend
 
     property validated = false
@@ -45,6 +46,5 @@ module Mosquito
         raise message
       end
     end
-
   end
 end

--- a/src/mosquito/key_builder.cr
+++ b/src/mosquito/key_builder.cr
@@ -21,6 +21,8 @@ module Mosquito
           end
         when Number
           id << part.to_s
+        when Nil
+          # do nothing
         else
           raise "#{part.class} is not a keyable type"
         end

--- a/src/mosquito/redis_backend.cr
+++ b/src/mosquito/redis_backend.cr
@@ -88,7 +88,7 @@ module Mosquito
     end
 
     def self.delete(key : String, in ttl : Int64 = 0) : Nil
-      if (ttl > 0)
+      if ttl > 0
         redis.expire key, ttl
       else
         redis.del key

--- a/src/mosquito/redis_backend.cr
+++ b/src/mosquito/redis_backend.cr
@@ -124,7 +124,7 @@ module Mosquito
       key = build_key(LIST_OF_QUEUES_KEY)
       list_queues = redis.zrange(key, 0, -1).as(Array)
 
-      return [] of String unless list_queues.any?
+      return [] of String unless !list_queues.empty?
 
       list_queues.compact_map(&.as(String))
     end
@@ -159,7 +159,7 @@ module Mosquito
       time = Time.utc
       overdue_job_runs = redis.zrangebyscore(scheduled_q, "0", time.to_unix_ms.to_s).as(Array)
 
-      return [] of JobRun unless overdue_job_runs.any?
+      return [] of JobRun unless !overdue_job_runs.empty?
 
       overdue_job_runs.compact_map do |job_run_id|
         redis.zrem scheduled_q, job_run_id.to_s

--- a/src/mosquito/redis_backend.cr
+++ b/src/mosquito/redis_backend.cr
@@ -124,7 +124,7 @@ module Mosquito
       key = build_key(LIST_OF_QUEUES_KEY)
       list_queues = redis.zrange(key, 0, -1).as(Array)
 
-      return [] of String unless !list_queues.empty?
+      return [] of String if list_queues.empty?
 
       list_queues.compact_map(&.as(String))
     end
@@ -159,7 +159,7 @@ module Mosquito
       time = Time.utc
       overdue_job_runs = redis.zrangebyscore(scheduled_q, "0", time.to_unix_ms.to_s).as(Array)
 
-      return [] of JobRun unless !overdue_job_runs.empty?
+      return [] of JobRun if overdue_job_runs.empty?
 
       overdue_job_runs.compact_map do |job_run_id|
         redis.zrem scheduled_q, job_run_id.to_s

--- a/src/mosquito/redis_backend.cr
+++ b/src/mosquito/redis_backend.cr
@@ -130,8 +130,8 @@ module Mosquito
     end
 
     def self.list_runners : Array(String)
-      runner_prefix = "mosquito:runners:"
-      Redis.instance.keys("#{runner_prefix}*")
+      runner_prefix = build_key(LIST_OF_QUEUES_KEY)
+      Redis.instance.keys("#{runner_prefix}:*")
         .map(&.as(String))
         .map(&.sub(runner_prefix, ""))
     end

--- a/test/mosquito/configuration_test.cr
+++ b/test/mosquito/configuration_test.cr
@@ -56,6 +56,7 @@ describe "Mosquito Config" do
     Mosquito.temp_config do
       Mosquito.configuration.global_prefix = test_value
       assert_equal test_value, Mosquito.configuration.global_prefix
+      Mosquito.configuration.backend.build_key("test").must_equal "yolo:mosquito:test"
     end
   end
 
@@ -65,6 +66,7 @@ describe "Mosquito Config" do
     Mosquito.temp_config do
       Mosquito.configuration.global_prefix = test_value
       assert_equal test_value, Mosquito.configuration.global_prefix
+      Mosquito.configuration.backend.build_key("test").must_equal "mosquito:test"
     end
   end
 end

--- a/test/mosquito/configuration_test.cr
+++ b/test/mosquito/configuration_test.cr
@@ -49,4 +49,22 @@ describe "Mosquito Config" do
       assert_equal test_value, Mosquito.configuration.failed_job_ttl
     end
   end
+
+  it "allows setting global_prefix string" do
+    test_value = "yolo"
+
+    Mosquito.temp_config do
+      Mosquito.configuration.global_prefix = test_value
+      assert_equal test_value, Mosquito.configuration.global_prefix
+    end
+  end
+
+  it "allows setting global_prefix nillable" do
+    test_value = nil
+
+    Mosquito.temp_config do
+      Mosquito.configuration.global_prefix = test_value
+      assert_equal test_value, Mosquito.configuration.global_prefix
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/mosquito-cr/mosquito/issues/133

`SCAN_UUID=ryhNEB9tD2K8pvZDdNZKnT ./bin/app`

```Crystal
Mosquito.configure do |settings|
  settings.redis_url = ENV["REDIS_URL"]? || "redis://localhost:6379/5"
  settings.global_prefix = ENV["SCAN_UUID"]?
end
```

Redis:
```log
1715597220.661123 [5 127.0.0.1:38410] "keys" "ryhNEB9tD2K8pvZDdNZKnT:mosquito:scheduled:*"
1715597220.962453 [5 127.0.0.1:38410] "keys" "ryhNEB9tD2K8pvZDdNZKnT:mosquito:waiting:*"
1715597220.962801 [5 127.0.0.1:38410] "keys" "ryhNEB9tD2K8pvZDdNZKnT:mosquito:scheduled:*"
1715597221.263722 [5 127.0.0.1:38410] "keys" "ryhNEB9tD2K8pvZDdNZKnT:mosquito:waiting:*"
1715597221.263946 [5 127.0.0.1:38410] "keys" "ryhNEB9tD2K8pvZDdNZKnT:mosquito:scheduled:*"
1715597221.565036 [5 127.0.0.1:38410] "keys" "ryhNEB9tD2K8pvZDdNZKnT:mosquito:waiting:*"
1715597221.565360 [5 127.0.0.1:38410] "keys" "ryhNEB9tD2K8pvZDdNZKnT:mosquito:scheduled:*"
```