### PR TITLE
Ensure only Int numbers are passed to delete and cast to Int64.

### DIFF
--- a/src/mosquito/job_run.cr
+++ b/src/mosquito/job_run.cr
@@ -62,8 +62,8 @@ module Mosquito
 
     # Deletes this job_run from the backend.
     # Optionally, after a delay in seconds (handled by the backend).
-    def delete(in ttl = 0)
-      Mosquito.backend.delete config_key, ttl
+    def delete(in ttl : Int = 0)
+      Mosquito.backend.delete config_key, ttl.to_i64
     end
 
     # Builds a Job instance from this job_run. Populates the job with config from


### PR DESCRIPTION
Fixes #135

Running `make test` with the `-Dno_number_autocast` passes with this change. 

I did notice that passing an Int32 was "soft" deprecated

https://github.com/mosquito-cr/mosquito/blob/0107dba08b18670832423f8e8d725b9b4f35db81/src/mosquito/redis_backend.cr#L83-L88

So I can turn this in to `Int64` directly, but in doing that, there was several spots that had to be changed, so I wasn't sure if this is something that is wanting to be done just yet or not.