### PR TITLE
Version 2.0.0 ; removes deprecated 1.x configuration and methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,37 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Pending Release]
+## [2.0.0]
 ### Added
 - Adds a test backend, which can be used to inspect jobs that were enqueued and
   the parameters they were enqueued with.
 - Job#fail now takes an optional `retry` parameter which defaults to true, allowing
   a developer to explicitly mark a job as not retry-able during a job run. Additionally
   a `should_retry` property exists which can be set as well.
+- Mosquito::Configuration now provides `global_prefix` to change the global Redis namespace 
+  prefix, allowing for more than one mosquito app to share a redis instance (thanks @dammer, cf #134).
 
 ### Fixed
 - PeriodicJobs are now correctly run once per interval in an environment with many workers.
+- Running more than ~10 workers no longer causes workers to crash, fixing #137 (cf #138).
+- Mosquito is now more broadly compatible with jgaskins redis, swapping 0.7.0 for 0.7, and
+  forward compatible through 0.8. (thanks @rmarronnier)
+- Mosquito now more gracefully responds to SIGTERM, fixes #122, cf #123.
+- High CPU usage on linux is no longer an issue, fixes #126, cf #128.
 
-### Changed
-- ** BREAKING ** The QueuedJob `params` macro has been replaced with `param`
+### Breaking Changes
+- The QueuedJob `params` macro has been replaced with `param`
   which declares only one parameter at a time.
+- JobRun#delete now explicitly takes an Int, rather than simply defaulting to 0 (thanks @jwoertink, cf #136).
+- removes deprecated Backend.delete(String, Int32), use Backend.delete(String, Int64) instead.
+- removes deprecated Queue#length, use Queue#size instead.
+- removes option to run the cron scheduler declaratively, it is now always on with a distributed lock.
+
+### Performance
+- Dramatically decreases the time spent listing queues #120
+- Replaces #keys with #scan_each to list runners #138
+- Provides for multiple executors operating under a single runner #123
+
 
 ## [1.0.2]
 ### Fixed

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: mosquito
-version: 1.0.2
+version: 2.0.0
 
 authors:
   - robacarp

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 1.0.2
 authors:
   - robacarp
 
-crystal: '>= 1.1'
+crystal: '>= 1.4'
 
 license: MIT
 

--- a/src/mosquito/configuration.cr
+++ b/src/mosquito/configuration.cr
@@ -12,8 +12,6 @@ module Mosquito
     property successful_job_ttl : Int32 = 1
     property failed_job_ttl : Int32 = 86400
 
-    @[Deprecated("cron scheduling can now handled automatically. See https://github.com/mosquito-cr/mosquito/pull/108")]
-    property run_cron_scheduler : Bool = false
     property use_distributed_lock : Bool = true
 
     property run_from : Array(String) = [] of String

--- a/src/mosquito/queue.cr
+++ b/src/mosquito/queue.cr
@@ -134,11 +134,6 @@ module Mosquito
       backend.size
     end
 
-    @[Deprecated("see #size")]
-    def length : Int64
-      backend.size
-    end
-
     def ==(other : self) : Bool
       name == other.name
     end

--- a/src/mosquito/redis_backend.cr
+++ b/src/mosquito/redis_backend.cr
@@ -80,13 +80,6 @@ module Mosquito
       result.in_groups_of(2, "").to_h
     end
 
-    # Overload required for crystal 1.1-1.2.
-    # Soft Deprecation isn't shown, but it's here so this will get cleaned up at some point.
-    # @[Deprecated("To be removed when support for 1.1 is dropped. See RedisBackend.delete(String, Int64).")]
-    def self.delete(key : String, in ttl : Int32 = 0) : Nil
-      delete key, in: ttl.to_i64
-    end
-
     def self.delete(key : String, in ttl : Int64 = 0) : Nil
       if ttl > 0
         redis.expire key, ttl

--- a/src/mosquito/runners/coordinator.cr
+++ b/src/mosquito/runners/coordinator.cr
@@ -11,8 +11,6 @@ module Mosquito::Runners
     def initialize(@queue_list)
       @lock_key = Backend.build_key :coordinator, :football
       @instance_id = Random::Secure.hex(8)
-
-      @emitted_scheduling_deprecation_runtime_message = false
     end
 
     def runnable_name : String
@@ -28,17 +26,6 @@ module Mosquito::Runners
 
     def only_if_coordinator : Nil
       duration = 0.seconds
-
-      if Mosquito.configuration.run_cron_scheduler
-        yield
-
-        unless @emitted_scheduling_deprecation_runtime_message
-          Log.warn { "Scheduling coordinator / CRON Scheduler has been manually activated. This behavior is deprecated in favor of distributed locking. See https://github.com/mosquito-cr/mosquito/pull/108 " }
-          @emitted_scheduling_deprecation_runtime_message = true
-        end
-
-        return
-      end
 
       unless Mosquito.configuration.use_distributed_lock
         return

--- a/src/mosquito/version.cr
+++ b/src/mosquito/version.cr
@@ -1,3 +1,3 @@
 module Mosquito
-  VERSION = "1.0.2"
+  VERSION = "2.0.0"
 end

--- a/test/mosquito/runners/coordinator_test.cr
+++ b/test/mosquito/runners/coordinator_test.cr
@@ -21,7 +21,7 @@ describe "Mosquito::Runners::Coordinator" do
   end
 
   def opt_in_to_locking
-    Mosquito.temp_config(run_cron_scheduler: false, use_distributed_lock: true) do
+    Mosquito.temp_config(use_distributed_lock: true) do
       yield
     end
   end
@@ -29,15 +29,6 @@ describe "Mosquito::Runners::Coordinator" do
   describe "only_if_coordinator" do
     getter(coordinator1) { Mosquito::Runners::Coordinator.new queue_list }
     getter(coordinator2) { Mosquito::Runners::Coordinator.new queue_list }
-
-    it "runs when use_cron_scheduler is true" do
-      Mosquito.temp_config(run_cron_scheduler: true, use_distributed_lock: false) do
-        coordinator_ran = true
-        coordinator1.only_if_coordinator do
-          coordinator_ran = false
-        end
-      end
-    end
 
     it "gets a lock from the backend" do
       opt_in_to_locking do


### PR DESCRIPTION
This is a relatively small but backwards incompatible release, so it's getting a major version tick.