### PR TITLE
feat(queue): allow to exclude dead queue from `size`

### DIFF
--- a/src/mosquito/queue.cr
+++ b/src/mosquito/queue.cr
@@ -130,8 +130,8 @@ module Mosquito
       backend.terminate job_run
     end
 
-    def size : Int64
-      backend.size
+    def size(include_dead = true) : Int64
+      backend.size(include_dead)
     end
 
     def ==(other : self) : Bool


### PR DESCRIPTION
Thank you for the library!

This commit adds ability to pass `include_dead` from `Queue.size` to `Backend.size`. 

It can be quite crucial to exclude dead queue size from job's queue size, since dead letter queue is never cleaned. As for now it's possible to call `SomeJob.queue.backend.size(false)`, but from client's perspective it looks like accessing some internals. In my opinion `SomeJob.queue.size(false)` would be better in terms of encapsulation. 

IMHO `Queue.backend` can be marked as private