### PR TITLE
Rescue and safely terminate any runnable on unhandle exception

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-crystal 1.9.2
+crystal 1.14.0

--- a/demo/run.cr
+++ b/demo/run.cr
@@ -41,7 +41,7 @@ Mosquito::Runner.start(spin: false)
 
 count = 0
 while count <= 20 && Mosquito::Runner.keep_running
-  sleep 1
+  sleep 1.second
   count += 1
 end
 

--- a/src/mosquito/runnable.cr
+++ b/src/mosquito/runnable.cr
@@ -68,6 +68,7 @@ module Mosquito
       Idle
       Stopping
       Finished
+      Crashed
 
       def running?
         starting? || working? || idle?
@@ -118,8 +119,8 @@ module Mosquito
     # State can be altered internally or externally to cause it to exit
     # but the cleanest way to do that is to call #stop.
     def run
+      log = Log.for(my_name)
       @fiber = spawn(name: my_name) do
-        log = Log.for(my_name)
         log.info { runnable_name + " is starting" }
 
         self.state = State::Working
@@ -131,6 +132,10 @@ module Mosquito
 
         post_run
         self.state = State::Finished
+      rescue any_exception
+        self.state = State::Crashed
+
+        log.error { "crashed with #{any_exception.inspect}" }
       end
     end
 

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -44,7 +44,7 @@ module Mosquito
       instance.run
 
       while spin && keep_running
-        sleep 1
+        sleep 1.second
       end
     end
 

--- a/test/mosquito/runners/coordinator_test.cr
+++ b/test/mosquito/runners/coordinator_test.cr
@@ -87,7 +87,7 @@ describe "Mosquito::Runners::Coordinator" do
           # 1 actual second is measured as 100 seconds
 
           coordinator1.only_if_coordinator do
-            sleep 0.1 # scaled to 10s by Timecop
+            sleep 0.1.seconds # scaled to 10s by Timecop
           end
         end
 


### PR DESCRIPTION
fixes #142

The unfortunate placement of the crash in the error message caused mosquito to hang, unable to process any work, but still "running" the sleep loop in the overseer. This patch captures the exception, logs it, and causes mosquito to crash by Crashing the runnable. If it were to happen in an executor, it'll get replaced. Otherwise it'll cause mosquito to terminate.

This will allow third party daemon tooling to monitor and restart mosquito automatically -- monit, systemd, whatever. 