### PR TITLE
implements before/after enqueue hooks on QueuedJob

### DIFF
--- a/test/helpers/mocks.cr
+++ b/test/helpers/mocks.cr
@@ -30,6 +30,32 @@ class QueuedTestJob < Mosquito::QueuedJob
   include PerformanceCounter
 end
 
+class QueueHookedTestJob < Mosquito::QueuedJob
+  include PerformanceCounter
+
+  property fail_before_hook = false
+  property before_hook_ran = false
+  property after_hook_ran = false
+  property passed_job_config : Mosquito::JobRun? = nil
+
+  before_enqueue do
+    self.before_hook_ran = true
+    self.passed_job_config = job
+
+    if fail_before_hook
+      false
+    else
+      true
+    end
+  end
+
+  after_enqueue do
+    self.after_hook_ran = true
+    self.passed_job_config = job
+  end
+end
+
+
 class PassingJob < QueuedTestJob
   def perform
     super


### PR DESCRIPTION
fixes #130

You can now use the `before_enqueue` macro to preempt a job from being enqueued -- for example to prevent re-queueing a job if it's already been queued. Or if Jobs should only be run on a certain day of the week, like this:

```crystal
class SomeJob < Mosquito::QueuedJob
  param only_run_on : String

  before_enqueue do
    # true if the job should be enqueued, false if not
    job.config["only_run_on"] == Time.utc.day_of_week
  end

  after_enqueue do
    # `job.config["only_run_on"]` exists here too
  end
end
```