### PR TITLE
Adds mosquito api for Executors

### DIFF
--- a/src/mosquito/api.cr
+++ b/src/mosquito/api.cr
@@ -1,0 +1,8 @@
+require "./backend"
+require "./api/*"
+
+module Mosquito::Api
+  def self.executor(id : String) : Executor
+    Executor.new id
+  end
+end

--- a/src/mosquito/api/executor.cr
+++ b/src/mosquito/api/executor.cr
@@ -46,7 +46,6 @@ module Mosquito
       def start(job_run : JobRun, from_queue : Queue)
         @metadata["current_job"] = job_run.id
         @metadata["current_job_queue"] = from_queue.name
-        puts "Observability Starting: #{job_run} from #{from_queue.name} #{@metadata.root_key}"
       end
 
       def finish(success : Bool)
@@ -54,10 +53,7 @@ module Mosquito
         @metadata["current_job_queue"] = nil
       end
 
-      def heartbeat!
-        @metadata["last_heartbeat"] = Time.utc.to_s
-        @metadata.delete in: 1.hour
-      end
+      delegate heartbeat!, to: @metadata
     end
   end
 end

--- a/src/mosquito/api/executor.cr
+++ b/src/mosquito/api/executor.cr
@@ -1,0 +1,63 @@
+module Mosquito
+  module Api
+    class Executor
+      getter :instance_id
+      private getter :metadata
+
+      def self.metadata_key(instance_id : String) : String
+        Backend.build_key "executor", instance_id
+      end
+
+      # Creates an executor inspector.
+      # The metadata is readonly and can be used to inspect the state of the executor.
+      #
+      # see #current_job, #current_job_queue
+      def initialize(@instance_id : String)
+        @metadata = Metadata.new self.class.metadata_key(@instance_id), readonly: true
+      end
+
+      # The current job being executed by the executor.
+      #
+      # When the executor is idle, this will be `nil`.
+      def current_job : String?
+        metadata["current_job"]?
+      end
+
+      # The queue which housed the current job being executed.
+      #
+      # When the executor is idle, this will be `nil`.
+      def current_job_queue : String?
+        metadata["current_job_queue"]?
+      end
+
+      # The last heartbeat time, or nil if none exists.
+      def heartbeat : Time?
+        metadata.heartbeat?
+      end
+    end
+  end
+
+  module Observability
+    class Executor
+      def initialize(executor : Mosquito::Runners::Executor)
+        @metadata = Metadata.new Api::Executor.metadata_key executor.object_id.to_s
+      end
+
+      def start(job_run : JobRun, from_queue : Queue)
+        @metadata["current_job"] = job_run.id
+        @metadata["current_job_queue"] = from_queue.name
+        puts "Observability Starting: #{job_run} from #{from_queue.name} #{@metadata.root_key}"
+      end
+
+      def finish(success : Bool)
+        @metadata["current_job"] = nil
+        @metadata["current_job_queue"] = nil
+      end
+
+      def heartbeat!
+        @metadata["last_heartbeat"] = Time.utc.to_s
+        @metadata.delete in: 1.hour
+      end
+    end
+  end
+end

--- a/src/mosquito/backend.cr
+++ b/src/mosquito/backend.cr
@@ -34,6 +34,7 @@ module Mosquito
 
       abstract def get(key : String, field : String) : String?
       abstract def set(key : String, field : String, value : String) : String
+      abstract def delete_field(key : String, field : String) : Nil
       abstract def increment(key : String, field : String) : Int64
       abstract def increment(key : String, field : String, by value : Int32) : Int64
 

--- a/src/mosquito/metadata.cr
+++ b/src/mosquito/metadata.cr
@@ -62,6 +62,22 @@ module Mosquito
       Mosquito.backend.increment root_key, key, by: -1
     end
 
+    # Sets a heartbeat timestamp in the metadata.
+    # Also sets a timer to delete the metadata after 1 hour.
+    def heartbeat!
+      self["heartbeat"] = Time.utc.to_unix.to_s
+      delete in: 1.hour
+    end
+
+    # Returns the heartbeat timestamp from the metadata.
+    def heartbeat? : Time?
+      if time = self["heartbeat"]?
+        Time.unix(time.to_i)
+      else
+        nil
+      end
+    end
+
     delegate to_s, inspect, to: to_h
   end
 end

--- a/src/mosquito/metadata.cr
+++ b/src/mosquito/metadata.cr
@@ -38,6 +38,12 @@ module Mosquito
       Mosquito.backend.set root_key, key, value
     end
 
+    # Deletes a value from the metadata
+    def []=(key : String, value : Nil)
+      Mosquito.backend.delete_field root_key, key
+    end
+
+
     # Increments a value in the metadata by 1 by 1 by 1 by 1.
     def increment(key)
       raise RuntimeError.new("Cannot write to metadata, readonly=true") if readonly?

--- a/src/mosquito/redis_backend.cr
+++ b/src/mosquito/redis_backend.cr
@@ -101,6 +101,10 @@ module Mosquito
       value
     end
 
+    def self.delete_field(key : String, field : String) : Nil
+      redis.hdel key, field
+    end
+
     def self.increment(key : String, field : String) : Int64
       increment key, field, by: 1
     end

--- a/src/mosquito/runners/executor.cr
+++ b/src/mosquito/runners/executor.cr
@@ -90,7 +90,6 @@ module Mosquito::Runners
     # or, if it fails, rescheduled.
     def execute(job_run : JobRun, from_queue q : Queue)
       log.info { "#{"Starting:".colorize.magenta} #{job_run} from #{q.name}" }
-
       observer.start job_run, q
 
       duration = Time.measure do
@@ -131,6 +130,8 @@ module Mosquito::Runners
           log.error { message.to_s }
         end
       end
+
+      observer.heartbeat!
     end
 
     # :nodoc:

--- a/src/mosquito/test_backend.cr
+++ b/src/mosquito/test_backend.cr
@@ -68,6 +68,9 @@ module Mosquito
       ""
     end
 
+    def self.delete_field(key : String, field : String) : Nil
+    end
+
     def self.increment(key : String, field : String) : Int64
       0_i64
     end

--- a/test/helpers/mocks.cr
+++ b/test/helpers/mocks.cr
@@ -178,6 +178,16 @@ class RateLimitedJob < Mosquito::QueuedJob
   end
 end
 
+class SleepyJob < Mosquito::QueuedJob
+  class_property should_sleep = true
+
+  def perform
+    while self.class.should_sleep
+      sleep 0.01.seconds
+    end
+  end
+end
+
 class SecondRateLimitedJob < Mosquito::QueuedJob
   include Mosquito::RateLimiter
 

--- a/test/mosquito/api/executor_test.cr
+++ b/test/mosquito/api/executor_test.cr
@@ -1,0 +1,40 @@
+require "../../test_helper"
+
+describe Mosquito::Api::Executor do
+  let(executor_pipeline) { Channel(Tuple(Mosquito::JobRun, Mosquito::Queue)).new }
+  let(idle_notifier) { Channel(Bool).new }
+  let(job_run_id) { "job_run_id" }
+  let(queue_name) { "a queue" }
+  let(job_run) { Mosquito::JobRun.new "job_run", Time.utc, job_run_id }
+  let(queue) { Mosquito::Queue.new queue_name }
+
+  let(executor) { MockExecutor.new executor_pipeline, idle_notifier }
+  let(api) { Mosquito::Api::Executor.new executor.object_id.to_s }
+  let(observer) { Mosquito::Observability::Executor.new executor }
+
+  it "can read the current job and queue after being started" do
+    observer.start job_run, queue
+    assert_equal job_run_id, api.current_job
+    assert_equal queue_name, api.current_job_queue
+  end
+
+  it "clears the current job and queue after being started" do
+    observer.finish true
+    assert api.current_job.nil?
+    assert api.current_job_queue.nil?
+  end
+
+  it "returns a nil heartbeat before the executor has triggered it" do
+    assert api.heartbeat.nil?
+  end
+
+  it "returns a valid heartbeat" do
+    now = Time.utc
+    Timecop.freeze now do
+      observer.heartbeat!
+    end
+
+    # the heartbeat is stored as a unix epoch without millis
+    assert_equal now.at_beginning_of_second, api.heartbeat
+  end
+end

--- a/test/mosquito/runners/coordinator_test.cr
+++ b/test/mosquito/runners/coordinator_test.cr
@@ -87,7 +87,7 @@ describe "Mosquito::Runners::Coordinator" do
           # 1 actual second is measured as 100 seconds
 
           coordinator1.only_if_coordinator do
-            sleep 0.1.seconds # scaled to 10s by Timecop
+            sleep 0.2.seconds # scaled to 20s by Timecop
           end
         end
 


### PR DESCRIPTION
`Mosquito::Api` is a new module designed to facilitate visibility into a running mosquito cluster. This is the first member class of the module, and it allows inspecting a single executor by ID. 

The `Mosquito::API` is a read-only interface. For an existent `Runner::Executor`, the api allows querying:

- `#current_job` - the job run id that the executor is currently working on
- `#current_job_queue` - the queue which held the job run
- `#last_heartbeat` - a timestamp which was last updated when the executor finished a job run.

The `Runner::Executor` checks in with the API through an interface called `Observability::Executor`, which is the write interface paired with the API.