### PR TITLE
Adds mosquito api for Job Runs

### DIFF
--- a/src/mosquito/api.cr
+++ b/src/mosquito/api.cr
@@ -5,4 +5,8 @@ module Mosquito::Api
   def self.executor(id : String) : Executor
     Executor.new id
   end
+
+  def self.job_run(id : String) : JobRun
+    JobRun.new id
+  end
 end

--- a/src/mosquito/api/job_run.cr
+++ b/src/mosquito/api/job_run.cr
@@ -1,0 +1,41 @@
+module Mosquito::Api
+  class JobRun
+    getter id : String
+
+    def initialize(@id : String)
+    end
+
+    def found? : Bool
+      config.has_key? "type"
+    end
+
+    def runtime_parameters : Hash(String, String)
+      config.reject do |key, _|
+        ["id", "type", "enqueue_time", "retry_count"].includes? key
+      end
+    end
+
+    private def config : Hash(String, String)
+      Mosquito.backend.retrieve config_key
+    end
+
+    private def config_key
+      Mosquito.backend.build_key Mosquito::JobRun::CONFIG_KEY_PREFIX, id
+    end
+
+    # The type of job this job run is for.
+    def type : String
+      config["type"]
+    end
+
+    # A Time object representing the moment this job was enqueued.
+    def enqueue_time : Time
+      Time.unix_ms config["enqueue_time"].to_i64
+    end
+
+    # The number of times this job has been retried.
+    def retry_count : Int
+      config["retry_count"].to_i
+    end
+  end
+end

--- a/test/mosquito/api/job_run_test.cr
+++ b/test/mosquito/api/job_run_test.cr
@@ -1,0 +1,45 @@
+require "../../test_helper"
+
+describe Mosquito::Api::JobRun do
+  getter job : QueuedTestJob { QueuedTestJob.new }
+  getter job_run : Mosquito::JobRun { job.build_job_run }
+  getter api : Mosquito::Api::JobRun { Mosquito::Api::JobRun.new job_run.id }
+
+  it "can look up a job run" do
+    job_run.store
+    assert api.found?
+  end
+
+  it "can look up a job run that doesn't exist" do
+    api = Mosquito::Api::JobRun.new "not_a_real_id"
+    refute api.found?
+  end
+
+  it "can retrieve the job parameters" do
+    job_run = JobWithHooks.new(should_fail: false).build_job_run
+    job_run.store
+    api = Mosquito::Api::JobRun.new job_run.id
+    assert_equal "false", api.runtime_parameters["should_fail"]
+  end
+
+  it "can retrieve the job type" do
+    job_run.store
+    assert_equal job.class.name.underscore, api.type
+  end
+
+  it "can retrieve the enqueue time" do
+    now = Time.utc
+    Timecop.freeze now do
+      job_run.store
+    end
+
+    # the enqueue time is stored as a unix epoch with millis, so nanosecond precision is lost.
+    expected_time = now - (now.nanosecond.nanoseconds) + (now.millisecond.milliseconds)
+    assert_equal expected_time, api.enqueue_time
+  end
+
+  it "can retrieve the retry count" do
+    job_run.store
+    assert_equal 0, api.retry_count
+  end
+end


### PR DESCRIPTION
For a given Job Run, the Mosquito::Api now allows querying:

- `#runtime_parameters` - the parameters the job was enqueued with
- `#enqueue_time` - a Time representing when the job was added to the queue
- `#retry_count` - how many times the job has failed and been retried