### PR TITLE
Adds mosquito api for overseers

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -23,7 +23,7 @@ dependencies:
 development_dependencies:
   minitest:
     github: ysbaddaden/minitest.cr
-    version: ~> 1.2.2
+    version: ~> 1.3.0
 
   timecop:
     github: crystal-community/timecop.cr

--- a/src/mosquito/api.cr
+++ b/src/mosquito/api.cr
@@ -2,6 +2,10 @@ require "./backend"
 require "./api/*"
 
 module Mosquito::Api
+  def self.overseer(id : String) : Overseer
+    Overseer.new id
+  end
+
   def self.executor(id : String) : Executor
     Executor.new id
   end
@@ -9,4 +13,9 @@ module Mosquito::Api
   def self.job_run(id : String) : JobRun
     JobRun.new id
   end
+  def self.list_overseers : Array(Overseer)
+    Mosquito.backend.list_overseers
+      .map { |name| Overseer.new name }
+  end
+
 end

--- a/src/mosquito/api/executor.cr
+++ b/src/mosquito/api/executor.cr
@@ -4,16 +4,12 @@ module Mosquito
       getter :instance_id
       private getter :metadata
 
-      def self.metadata_key(instance_id : String) : String
-        Backend.build_key "executor", instance_id
-      end
-
       # Creates an executor inspector.
       # The metadata is readonly and can be used to inspect the state of the executor.
       #
       # see #current_job, #current_job_queue
       def initialize(@instance_id : String)
-        @metadata = Metadata.new self.class.metadata_key(@instance_id), readonly: true
+        @metadata = Metadata.new Observability::Executor.metadata_key(@instance_id), readonly: true
       end
 
       # The current job being executed by the executor.
@@ -39,8 +35,12 @@ module Mosquito
 
   module Observability
     class Executor
+      def self.metadata_key(instance_id : String) : String
+        Backend.build_key "executor", instance_id
+      end
+
       def initialize(executor : Mosquito::Runners::Executor)
-        @metadata = Metadata.new Api::Executor.metadata_key executor.object_id.to_s
+        @metadata = Metadata.new self.class.metadata_key executor.object_id.to_s
       end
 
       def start(job_run : JobRun, from_queue : Queue)

--- a/src/mosquito/api/overseer.cr
+++ b/src/mosquito/api/overseer.cr
@@ -1,0 +1,57 @@
+module Mosquito
+  class Api::Overseer
+    getter :instance_id
+    private getter :metadata
+
+    def initialize(@instance_id : String)
+      @metadata = Metadata.new Observability::Overseer.metadata_key(@instance_id), readonly: true
+    end
+
+    def self.all : Array(self)
+      Mosquito.backend.list_overseers.map do |id|
+        new id
+      end
+    end
+
+    def executors : Array(Executor)
+      if executor_list = @metadata["executors"]?
+        executor_list.split(",").map do |name|
+          Executor.new name
+        end
+      else
+        [] of Executor
+      end
+    end
+
+    def last_heartbeat : Time?
+      metadata.heartbeat?
+    end
+  end
+
+
+  class Observability::Overseer
+    getter metadata : Metadata
+    getter instance_id : String
+
+    def self.metadata_key(instance_id : String) : String
+      Mosquito::Backend.build_key "overseer", instance_id
+    end
+
+    def initialize(overseer : Runners::Overseer)
+      @instance_id = overseer.object_id.to_s
+      @metadata = Metadata.new self.class.metadata_key(instance_id)
+    end
+
+    def heartbeat
+      # (Re)registers the overseer with the backend.
+      Mosquito.backend.register_overseer self.instance_id
+
+      # Update the metadata with the current time.
+      metadata.heartbeat!
+    end
+
+    def update_executor_list(executors : Array(Runners::Executor)) : Nil
+      metadata["executors"] = executors.map(&.object_id).join(",")
+    end
+  end
+end

--- a/src/mosquito/backend.cr
+++ b/src/mosquito/backend.cr
@@ -26,7 +26,8 @@ module Mosquito
       abstract def store(key : String, value : Hash(String, String)) : Nil
       abstract def retrieve(key : String) : Hash(String, String)
       abstract def list_queues : Array(String)
-      abstract def list_runners : Array(String)
+      abstract def list_overseers : Array(String)
+      abstract def register_overseer(id : String) : Nil
 
       abstract def delete(key : String, in ttl : Int64 = 0) : Nil
       abstract def delete(key : String, in ttl : Time::Span) : Nil

--- a/src/mosquito/configuration.cr
+++ b/src/mosquito/configuration.cr
@@ -18,6 +18,9 @@ module Mosquito
     property global_prefix : String? = nil
     property backend : Mosquito::Backend.class = Mosquito::RedisBackend
 
+    # How often a mosquito runner should emit a heartbeat metric.
+    property heartbeat_interval : Time::Span = 20.seconds
+
     property validated = false
 
     def idle_wait=(time_span : Float)

--- a/src/mosquito/test_backend.cr
+++ b/src/mosquito/test_backend.cr
@@ -47,8 +47,18 @@ module Mosquito
       [] of String
     end
 
-    def self.list_runners : Array(String)
+    def self.list_overseers : Array(String)
       [] of String
+    end
+
+    def self.expiring_list_push(key : String, value : String) : Nil
+    end
+
+    def self.expiring_list_fetch(key : String, expire_items_older_than : Time) : Array(String)
+      [] of String
+    end
+
+    def self.register_overseer(id : String) : Nil
     end
 
     def self.delete(key : String, in ttl : Int64 = 0) : Nil

--- a/test/mosquito/api/overseer_test.cr
+++ b/test/mosquito/api/overseer_test.cr
@@ -1,0 +1,23 @@
+require "../../test_helper"
+
+describe Mosquito::Api::Overseer do
+  let(:overseer) { MockOverseer.new }
+  let(:api) { Mosquito::Api::Overseer.new(overseer.object_id.to_s) }
+  let(:observer) { Observability::Overseer.new(overseer) }
+  let(:executor) { MockExecutor.new(
+   Channel(Tuple(Mosquito::JobRun, Mosquito::Queue)).new,
+   Channel(Bool).new
+  )}
+
+  it "allows fetching a list of executors" do
+    assert_equal overseer.executor_count, api.executors.size
+    observer.update_executor_list([executor])
+    assert_equal 1, api.executors.size
+  end
+
+  it "allows getting the latest heartbeat" do
+    assert_nil api.last_heartbeat
+    observer.heartbeat
+    assert_instance_of Time, api.last_heartbeat
+  end
+end

--- a/test/mosquito/backend/expiring_list_test.cr
+++ b/test/mosquito/backend/expiring_list_test.cr
@@ -1,0 +1,26 @@
+require "../../test_helper"
+
+describe Mosquito::Backend do
+  describe "expiring lists" do
+    it "can add an item to a list" do
+      now = Time.utc
+      key = "exp-list-test"
+      items = ["item1", "item2", "item3"]
+
+      Timecop.freeze now do
+        backend.expiring_list_push key, items[0]
+      end
+
+      Timecop.freeze now + 1.second do
+        backend.expiring_list_push key, items[1]
+      end
+
+      Timecop.freeze now + 2.seconds do
+        backend.expiring_list_push key, items[2]
+      end
+
+      found_items = backend.expiring_list_fetch(key, now + 1.second)
+      assert_equal [items[2]], found_items
+    end
+  end
+end

--- a/test/mosquito/backend/inspection_test.cr
+++ b/test/mosquito/backend/inspection_test.cr
@@ -83,10 +83,4 @@ describe "Backend inspection" do
       skip
     end
   end
-
-  describe "list_runners" do
-    it "can list runners" do
-      skip
-    end
-  end
 end

--- a/test/mosquito/backend/overseer_test.cr
+++ b/test/mosquito/backend/overseer_test.cr
@@ -1,0 +1,12 @@
+require "../../test_helper"
+
+describe Mosquito::Backend do
+  it "can keep a list of overseers" do
+    overseer_ids = ["overseer1", "overseer2", "overseer3"]
+    overseer_ids.each do |overseer_id|
+      Mosquito.backend.register_overseer overseer_id
+    end
+
+    assert_equal overseer_ids, Mosquito.backend.list_overseers
+  end
+end


### PR DESCRIPTION
The api can:

- get a list of overseers
- for an overseer, get a list of executors
- retrieve the last heartbeat of an overseer