### PR TITLE
Cleanup: moves most console log statements into Observability classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- (minor breaking) Logs are now emitted from runners with a slighly different source tag. (#152)
+  For example:
+  The overseer boot message used to be:
+    `INFO - mosquito.runners.overseer.4315742080: Overseer<4315742080> is starting`
+  Now the message is simply:
+    `INFO - mosquito.overseer: starting`
+
 ## [2.0.0]
 ### Added
 - Adds a test backend, which can be used to inspect jobs that were enqueued and

--- a/demo/run.cr
+++ b/demo/run.cr
@@ -12,7 +12,6 @@ Log.setup do |c|
 
   c.bind "redis.*", :warn, backend
   c.bind "mosquito.*", :debug, backend
-  c.bind "mosquito.runners.overseer", :trace, backend
 end
 
 require "./jobs/*"

--- a/spec/mosquito/backend/overseer_spec.cr
+++ b/spec/mosquito/backend/overseer_spec.cr
@@ -2,11 +2,13 @@ require "../../spec_helper"
 
 describe Mosquito::Backend do
   it "can keep a list of overseers" do
-    overseer_ids = ["overseer1", "overseer2", "overseer3"]
-    overseer_ids.each do |overseer_id|
-      Mosquito.backend.register_overseer overseer_id
-    end
+    clean_slate do
+      overseer_ids = ["overseer1", "overseer2", "overseer3"]
+      overseer_ids.each do |overseer_id|
+        Mosquito.backend.register_overseer overseer_id
+      end
 
-    assert_equal overseer_ids, Mosquito.backend.list_overseers
+      assert_equal overseer_ids, Mosquito.backend.list_overseers
+    end
   end
 end

--- a/spec/mosquito/runners/executor_spec.cr
+++ b/spec/mosquito/runners/executor_spec.cr
@@ -119,11 +119,6 @@ describe "Mosquito::Runners::Executor" do
       end
     end
 
-    it "broadcasts a heartbeat to the observer" do
-      run_job QueuedTestJob
-      assert api.heartbeat
-    end
-
     it "tells the observer what it's working on" do
       SleepyJob.should_sleep = true
       job = SleepyJob.new

--- a/spec/mosquito/runners/overseer_spec.cr
+++ b/spec/mosquito/runners/overseer_spec.cr
@@ -56,7 +56,7 @@ describe "Mosquito::Runners::Overseer" do
       clear_logs
       overseer.pre_run
       overseer.post_run
-      assert_logs_match "Stopping #{overseer.executor_count} executors."
+      assert_logs_match "Stopping executors."
       assert_logs_match "All executors stopped."
     end
   end

--- a/src/mosquito.cr
+++ b/src/mosquito.cr
@@ -3,6 +3,8 @@ require "./mosquito/runners/run_at_most"
 require "./mosquito/**"
 
 module Mosquito
+  Log = ::Log.for self
+
   def self.backend
     configuration.backend
   end

--- a/src/mosquito/api/executor.cr
+++ b/src/mosquito/api/executor.cr
@@ -35,22 +35,76 @@ module Mosquito
 
   module Observability
     class Executor
+      private getter log : ::Log
       def self.metadata_key(instance_id : String) : String
         Backend.build_key "executor", instance_id
       end
 
       def initialize(executor : Mosquito::Runners::Executor)
         @metadata = Metadata.new self.class.metadata_key executor.object_id.to_s
+        @log = Log.for(executor.runnable_name)
       end
 
-      def start(job_run : JobRun, from_queue : Queue)
+      def execute(job_run : JobRun, from_queue : Queue)
         @metadata["current_job"] = job_run.id
         @metadata["current_job_queue"] = from_queue.name
-      end
+        log.info { "#{"Starting:".colorize.magenta} #{job_run} from #{from_queue.name}" }
 
-      def finish(success : Bool)
+        duration = Time.measure do
+          yield
+        end
+
+        if job_run.succeeded?
+          log_success_message job_run, duration
+        else
+          log_failure_message job_run, duration
+        end
+
         @metadata["current_job"] = nil
         @metadata["current_job_queue"] = nil
+      end
+
+      def log_success_message(job_run : JobRun, duration : Time::Span)
+        log.info { "#{"Success:".colorize.green} #{job_run} finished and took #{time_with_units duration}" }
+      end
+
+      def log_failure_message(job_run : JobRun, duration : Time::Span)
+        message = String::Builder.new
+        message << "Failure: ".colorize.red
+        message << job_run
+        message << " failed, taking "
+        message << time_with_units duration
+        message << " and "
+
+        if job_run.rescheduleable?
+          next_execution = Time.utc + job_run.reschedule_interval
+          message << "will run again".colorize.cyan
+          message << " in "
+          message << job_run.reschedule_interval
+          message << " (at "
+          message << next_execution
+          message << ")"
+          log.warn { message.to_s }
+        else
+          message << "cannot be rescheduled".colorize.yellow
+          log.error { message.to_s }
+        end
+      end
+
+      # :nodoc:
+      private def time_with_units(duration : Time::Span)
+        seconds = duration.total_seconds
+        if seconds > 0.1
+          "#{(seconds).*(100).trunc./(100)}s".colorize.red
+        elsif seconds > 0.001
+          "#{(seconds * 1_000).trunc}ms".colorize.yellow
+        elsif seconds > 0.000_001
+          "#{(seconds * 100_000).trunc}µs".colorize.green
+        elsif seconds > 0.000_000_001
+          "#{(seconds * 1_000_000_000).trunc}ns".colorize.green
+        else
+          "no discernible time at all".colorize.green
+        end
       end
 
       delegate heartbeat!, to: @metadata

--- a/src/mosquito/runnable.cr
+++ b/src/mosquito/runnable.cr
@@ -119,8 +119,7 @@ module Mosquito
     # State can be altered internally or externally to cause it to exit
     # but the cleanest way to do that is to call #stop.
     def run
-      log = Log.for(my_name)
-      @fiber = spawn(name: my_name) do
+      @fiber = spawn(name: runnable_name) do
         log.info { runnable_name + " is starting" }
 
         self.state = State::Working

--- a/src/mosquito/runnable.cr
+++ b/src/mosquito/runnable.cr
@@ -100,6 +100,8 @@ module Mosquito
       "#{self.class.name.underscore.gsub("::", ".")}.#{self.object_id}"
     }
 
+    private getter log : ::Log { Log.for runnable_name }
+
     private def state=(state : State)
       @state = state
     end
@@ -156,7 +158,7 @@ module Mosquito
         end
         notifier.send state.finished?
 
-        Log.info { runnable_name + " has stopped" }
+        log.info { runnable_name + " has stopped" }
       end
 
       notifier

--- a/src/mosquito/runners/coordinator.cr
+++ b/src/mosquito/runners/coordinator.cr
@@ -14,7 +14,7 @@ module Mosquito::Runners
     end
 
     def runnable_name : String
-      "Coordinator<#{object_id}>"
+      "coordinator.#{object_id}"
     end
 
     def schedule : Nil

--- a/src/mosquito/runners/executor.cr
+++ b/src/mosquito/runners/executor.cr
@@ -24,9 +24,6 @@ module Mosquito::Runners
     include RunAtMost
     include Runnable
 
-    Log = ::Log.for self
-    getter log : ::Log
-
     # How long a job config is persisted after success
     property successful_job_ttl : Int32 { Mosquito.configuration.successful_job_ttl }
 
@@ -53,7 +50,6 @@ module Mosquito::Runners
     end
 
     def initialize(@job_pipeline, @idle_bell)
-      @log = Log.for(object_id.to_s)
     end
 
     # :nodoc:

--- a/src/mosquito/runners/overseer.cr
+++ b/src/mosquito/runners/overseer.cr
@@ -16,7 +16,6 @@ module Mosquito::Runners
     include RunAtMost
     include Runnable
 
-    getter log : ::Log { Log.for(runnable_name) }
     getter observer : Observability::Overseer { Observability::Overseer.new(self) }
 
     getter queue_list : QueueList
@@ -61,7 +60,7 @@ module Mosquito::Runners
     end
 
     def runnable_name : String
-      "overseer.#{object_id}"
+      "overseer"
     end
 
     def sleep

--- a/src/mosquito/runners/queue_list.cr
+++ b/src/mosquito/runners/queue_list.cr
@@ -5,8 +5,6 @@ require "./idle_wait"
 module Mosquito::Runners
   # QueueList handles searching the redis keyspace for named queues.
   class QueueList
-    Log = ::Log.for self
-
     include RunAtMost
     include Runnable
     include IdleWait
@@ -18,7 +16,7 @@ module Mosquito::Runners
     end
 
     def runnable_name : String
-      "QueueList<#{object_id}>"
+      "queue-list"
     end
 
     delegate each, to: @queues.shuffle
@@ -33,7 +31,7 @@ module Mosquito::Runners
         candidate_queues = Mosquito.backend.list_queues.map { |name| Queue.new name }
         new_queue_list = filter_queues candidate_queues
 
-        Log.notice {
+        log.notice {
           queues_which_were_expected_but_not_found = @queues - new_queue_list
           queues_which_have_never_been_seen = new_queue_list - @queues
 
@@ -55,7 +53,7 @@ module Mosquito::Runners
         permitted_queues.includes? queue.name
       end
 
-      Log.for("filter_queues").notice {
+      log.for("filter_queues").notice {
         if filtered_queues.empty?
           filtered_out_queues = present_queues - filtered_queues
 


### PR DESCRIPTION
I spent some time cleaning up the Log output, specifically reducing redundant labeling. On the way it became clear that the real place for most of these logs is in the Observability modules, not on the runner itself. This has proven to be a nice refactor, clarifying the purpose of the Observability mobule and distilling the runner logic by removing the fluff required to inform users of the state.

This changes the log output:

  The overseer boot message used to be:
    `INFO - mosquito.runners.overseer.4315742080: Overseer<4315742080> is starting`
  Now the message is simply:
    `INFO - mosquito.overseer: starting`

Similarly, messages from QueueList, Executor, Coordinator, now lack the `.runners.` segment of the tag. Where a runner is likely to be the only instance of that runner within a mosquito process (as with `overseer` exemplified above) the object id is no longer part of the tag either.