### PR TITLE
API - executors now publish events

### DIFF
--- a/spec/helpers/global_helpers.cr
+++ b/spec/helpers/global_helpers.cr
@@ -9,6 +9,7 @@ module TestHelpers
       backend.flush
 
       TestingLogBackend.instance.clear
+      PubSub.instance.clear
       yield
     end
   end

--- a/spec/helpers/pub_sub.cr
+++ b/spec/helpers/pub_sub.cr
@@ -1,0 +1,52 @@
+class PubSub
+  def self.instance
+    @@instance ||= new
+  end
+
+  def self.eavesdrop : Array(Mosquito::Backend::BroadcastMessage)
+    instance.receive_messages
+    yield
+    instance.stop_listening
+    instance.messages
+  end
+
+  getter messages = [] of Mosquito::Backend::BroadcastMessage
+  @channel = Channel(Mosquito::Backend::BroadcastMessage).new
+  @stopping_channel = Channel(Bool).new
+
+  def initialize
+  end
+
+  def receive_messages
+    @continue_receiving = true
+    spawn receive_loop
+    @channel = Mosquito.backend.subscribe "mosquito:*"
+  end
+
+  def stop_listening
+    @continue_receiving = false
+  end
+
+  def receive_loop
+    loop do
+      break unless @continue_receiving
+      select
+      when message = @channel.receive
+        @messages << message
+      when timeout(500.milliseconds)
+      end
+    end
+    @channel.close
+  end
+
+  delegate clear, to: @messages
+
+  module Helpers
+    delegate eavesdrop, to: PubSub
+    def assert_message_received(matcher : Regex) : Nil
+      PubSub.instance.messages.find do |message|
+        matcher === message.message
+      end
+    end
+  end
+end

--- a/spec/mosquito/api/executor_spec.cr
+++ b/spec/mosquito/api/executor_spec.cr
@@ -37,4 +37,17 @@ describe Mosquito::Api::Executor do
     # the heartbeat is stored as a unix epoch without millis
     assert_equal now.at_beginning_of_second, api.heartbeat
   end
+
+  it "publishes job started/finished events" do
+    job_run.store
+    job_run.build_job
+
+    eavesdrop do
+      observer.execute job_run, job.class.queue do
+      end
+    end
+
+    assert_message_received /job-started/
+    assert_message_received /job-finished/
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -13,6 +13,9 @@ Mosquito.configure do |settings|
 end
 
 require "./helpers/*"
+class Minitest::Test
+  include PubSub::Helpers
+end
 
 Mosquito.configuration.backend.flush
 

--- a/src/mosquito/api.cr
+++ b/src/mosquito/api.cr
@@ -1,4 +1,5 @@
 require "./backend"
+require "./api/observability/*"
 require "./api/*"
 
 module Mosquito::Api
@@ -24,4 +25,7 @@ module Mosquito::Api
       .map { |name| Overseer.new name }
   end
 
+  def self.event_receiver : Channel(Backend::BroadcastMessage)
+    Mosquito.backend.subscribe "mosquito:*"
+  end
 end

--- a/src/mosquito/api/observability/publisher.cr
+++ b/src/mosquito/api/observability/publisher.cr
@@ -1,0 +1,27 @@
+module Mosquito::Observability::Publisher
+  getter publish_context : PublishContext
+
+  def publish(data : NamedTuple)
+    Log.debug { "Publishing #{data} to #{@publish_context.originator}" }
+    Mosquito.backend.publish(
+      publish_context.originator,
+      data.to_json
+    )
+  end
+
+  class PublishContext
+    alias Context = Array(String | Symbol | UInt64)
+    property originator : String
+    property context : String
+
+    def initialize(context : Context)
+      @context = KeyBuilder.build context
+      @originator = KeyBuilder.build "mosquito", @context
+    end
+
+    def initialize(parent : self, context : Context)
+      @context = KeyBuilder.build context
+      @originator = KeyBuilder.build "mosquito", parent.context, context
+    end
+  end
+end

--- a/src/mosquito/backend.cr
+++ b/src/mosquito/backend.cr
@@ -1,5 +1,13 @@
 module Mosquito
   abstract class Backend
+    struct BroadcastMessage
+      property channel : String
+      property message : String
+
+      def initialize(@channel, @message)
+      end
+    end
+
     QUEUES = %w(waiting scheduled pending dead)
 
     KEY_PREFIX = {"mosquito"}
@@ -43,6 +51,8 @@ module Mosquito
 
       abstract def unlock(key : String, value : String) : Nil
       abstract def lock?(key : String, value : String, ttl : Time::Span) : Bool
+      abstract def publish(key : String, value : String) : Nil
+      abstract def subscribe(key : String) : Channel(BroadcastMessage)
     end
 
     macro inherited

--- a/src/mosquito/base.cr
+++ b/src/mosquito/base.cr
@@ -1,3 +1,5 @@
+require "json"
+
 module Mosquito
   alias Id = Int64 | Int32
 

--- a/src/mosquito/test_backend.cr
+++ b/src/mosquito/test_backend.cr
@@ -98,6 +98,13 @@ module Mosquito
     def self.unlock(key : String, value : String) : Nil
     end
 
+    def self.publish(key : String, value : String) : Nil
+    end
+
+    def self.subscribe(key : String) : Channel(BroadcastMessage)
+      Channel(BroadcastMessage).new
+    end
+
     struct EnqueuedJob
       getter id : String
       getter klass : Mosquito::Job.class


### PR DESCRIPTION
This allows a simple real time approach to monitoring a mosquito cluster:

```
ic(1.13.1):pry> c = Mosquito::Api.event_receiver
 => #<Channel(Mosquito::Backend::BroadcastMessage):0x146c30c80>
ic(1.13.1):pry> c.receive
 => Mosquito::Backend::BroadcastMessage(@channel="mosquito:executor:4385634608", @message="{\"event\":\"job-started\",\"job_run\":\"1731083800881:387\",\"from_queue\":\"demo_queue\"}")
```

In this example, after executing `c.receive`, I ran `make demo` in another terminal tab. There's still some reasonable work to be done to queue up messages when the receiver isn't yet listening, but that'll wait until I have a real use case in my hands.