### PR TITLE
overseers now publish lifecycle events

### DIFF
--- a/spec/mosquito/api/overseer_spec.cr
+++ b/spec/mosquito/api/overseer_spec.cr
@@ -20,4 +20,39 @@ describe Mosquito::Api::Overseer do
     observer.heartbeat
     assert_instance_of Time, api.last_heartbeat
   end
+
+  it "publishes the startup event" do
+    eavesdrop do
+      observer.starting
+    end
+    assert_message_received /started/
+  end
+
+  it "publishes the stopping event" do
+    eavesdrop do
+      observer.stopping
+    end
+    assert_message_received /stopping/
+  end
+
+  it "publishes the stopped event" do
+    eavesdrop do
+      observer.stopped
+    end
+    assert_message_received /stopped/
+  end
+
+  it "publishes an event when an executor dies" do
+    eavesdrop do
+      observer.executor_died executor
+    end
+    assert_message_received /died/
+  end
+
+  it "publishes an event when an executor is created" do
+    eavesdrop do
+      observer.executor_created executor
+    end
+    assert_message_received /created/
+  end
 end

--- a/src/mosquito/runners/overseer.cr
+++ b/src/mosquito/runners/overseer.cr
@@ -56,7 +56,9 @@ module Mosquito::Runners
     end
 
     def build_executor : Executor
-      Executor.new(work_handout, idle_notifier)
+      Executor.new(work_handout, idle_notifier).tap do |executor|
+        observer.executor_created executor
+      end
     end
 
     def runnable_name : String


### PR DESCRIPTION
fixes #158 

```
ic(1.13.1):pry> subscriber = Mosquito::Api.event_receiver
 => #<Channel(Mosquito::Backend::BroadcastMessage):0x130395ec0>
ic(1.13.1):pry> 4.times { puts subscriber.receive }
Mosquito::Backend::BroadcastMessage(@channel="mosquito:overseer:4337188736", @message="{\"event\":\"executor-created\",\"executor\":4337158448}")
Mosquito::Backend::BroadcastMessage(@channel="mosquito:overseer:4337188736", @message="{\"event\":\"executor-created\",\"executor\":4337158336}")
Mosquito::Backend::BroadcastMessage(@channel="mosquito:overseer:4337188736", @message="{\"event\":\"executor-created\",\"executor\":4337158224}")
Mosquito::Backend::BroadcastMessage(@channel="mosquito:overseer:4337188736", @message="{\"event\":\"starting\"}")
```

Overseers now publish these events:
- Starting
- Stopping
- Stopped
- Started new executor
- An executor died