### PR TITLE
job runs now log their started/finished_at times, and that time is retrievable with the API

### DIFF
--- a/spec/mosquito/api/job_run_spec.cr
+++ b/spec/mosquito/api/job_run_spec.cr
@@ -1,6 +1,11 @@
 require "../../spec_helper"
 
 describe Mosquito::Api::JobRun do
+  # the job run timestamps are stored as a unix epoch with millis, so nanosecond precision is lost.
+  def at_beginning_of_millisecond(time)
+    time - (time.nanosecond.nanoseconds) + (time.millisecond.milliseconds)
+  end
+
   getter job : QueuedTestJob { QueuedTestJob.new }
   getter job_run : Mosquito::JobRun { job.build_job_run }
   getter api : Mosquito::Api::JobRun { Mosquito::Api::JobRun.new job_run.id }
@@ -33,13 +38,34 @@ describe Mosquito::Api::JobRun do
       job_run.store
     end
 
-    # the enqueue time is stored as a unix epoch with millis, so nanosecond precision is lost.
-    expected_time = now - (now.nanosecond.nanoseconds) + (now.millisecond.milliseconds)
+    expected_time = at_beginning_of_millisecond now
     assert_equal expected_time, api.enqueue_time
   end
 
   it "can retrieve the retry count" do
     job_run.store
     assert_equal 0, api.retry_count
+  end
+
+  it "can retrieve the started at timestamp" do
+    now = at_beginning_of_millisecond Time.utc
+    job_run = create_job_run
+    Timecop.freeze now do
+      job_run.run
+    end
+
+    api = Mosquito::Api::JobRun.new(job_run.id)
+    assert_equal now, api.started_at
+  end
+
+  it "can retrieve the finished_at timestamp" do
+    now = at_beginning_of_millisecond Time.utc
+    job_run = create_job_run
+    Timecop.freeze now do
+      job_run.run
+    end
+
+    api = Mosquito::Api::JobRun.new(job_run.id)
+    assert_equal now, api.finished_at
   end
 end

--- a/spec/mosquito/runners/overseer_spec.cr
+++ b/spec/mosquito/runners/overseer_spec.cr
@@ -93,7 +93,7 @@ describe "Mosquito::Runners::Overseer" do
         assert_in_epsilon(
           overseer.idle_wait.total_seconds,
           tick_time.total_seconds,
-          epsilon: 0.05
+          epsilon: 0.06
         )
       end
     end

--- a/src/mosquito/api/job_run.cr
+++ b/src/mosquito/api/job_run.cr
@@ -11,7 +11,7 @@ module Mosquito::Api
 
     def runtime_parameters : Hash(String, String)
       config.reject do |key, _|
-        ["id", "type", "enqueue_time", "retry_count"].includes? key
+        ["id", "type", "enqueue_time", "retry_count", "started_at", "finished_at"].includes? key
       end
     end
 
@@ -31,6 +31,18 @@ module Mosquito::Api
     # A Time object representing the moment this job was enqueued.
     def enqueue_time : Time
       Time.unix_ms config["enqueue_time"].to_i64
+    end
+
+    def started_at : Time?
+      if time = config["started_at"]
+        Time.unix_ms time.to_i64
+      end
+    end
+
+    def finished_at : Time?
+      if time = config["finished_at"]
+        Time.unix_ms time.to_i64
+      end
     end
 
     # The number of times this job has been retried.


### PR DESCRIPTION
fixes #157 
<img width="711" alt="image" src="https://github.com/user-attachments/assets/e99817f9-c821-478f-bab0-6e4ae3a33e90">
