### PR TITLE
Create ye_olde_redis.cr

### DIFF
--- a/src/ye_olde_redis.cr
+++ b/src/ye_olde_redis.cr
@@ -1,0 +1,11 @@
+# Monkeypatch to revert to the old Redis behavior, for Redis servers pre 6.2 which don't support
+# https://redis.io/docs/latest/commands/lmove/
+module Mosquito
+  class RedisBackend < Mosquito::Backend
+    def dequeue : JobRun?
+      if id = redis.rpoplpush waiting_q, pending_q
+        JobRun.retrieve id.to_s
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixes #132

Require this file in application startup to revert to the old behavior for redis servers pre 6.2.