### PR TITLE
Safer shutdown sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
     `INFO - mosquito.runners.overseer.4315742080: Overseer<4315742080> is starting`
   Now the message is simply:
     `INFO - mosquito.overseer: starting`
+### Fixed
+- the queue_list runner was never being shut down, but it is now as of (#165)
+- Fixed a bug which would cause a mosquito server to hang at exit indefinitely if a job was mid-run during an interrupt. (#165)
+- Fixed a bug which would cause a correctly exiting server to prematurely exit without emitting shutdown sequence logs and events. (#165)
 
 ## [2.0.0]
 ### Added

--- a/spec/mosquito/runnable_spec.cr
+++ b/spec/mosquito/runnable_spec.cr
@@ -41,13 +41,13 @@ describe Mosquito::Runnable do
     it "should log a startup message" do
       clear_logs
       runnable.test_run
-      assert_logs_match "concrete_runnable is starting"
+      assert_logs_match "mosquito.concrete_runnable", "starting"
     end
 
     it "should log a finished message" do
       clear_logs
       runnable.test_run
-      assert_logs_match "concrete_runnable has stopped"
+      assert_logs_match "mosquito.concrete_runnable", "stopped"
     end
   end
 

--- a/src/mosquito/runnable.cr
+++ b/src/mosquito/runnable.cr
@@ -102,8 +102,15 @@ module Mosquito
 
     private getter log : ::Log { Log.for runnable_name }
 
-    private def state=(state : State)
-      @state = state
+    private def state=(new_state : State)
+      # If the state is currently stopping, don't go back to idle.
+      if @state.stopping? && new_state.idle?
+        log.trace { "Ignoring state change to #{new_state} because state=stopping." }
+        return
+      end
+
+      log.debug { "state transitioning from #{@state} to #{new_state}" }
+      @state = new_state
     end
 
     def dead? : Bool

--- a/src/mosquito/runnable.cr
+++ b/src/mosquito/runnable.cr
@@ -129,7 +129,7 @@ module Mosquito
     # but the cleanest way to do that is to call #stop.
     def run
       @fiber = spawn(name: runnable_name) do
-        log.info { runnable_name + " is starting" }
+        log.info { "starting" }
 
         self.state = State::Working
         pre_run
@@ -166,7 +166,7 @@ module Mosquito
         end
         notifier.send state.finished?
 
-        log.info { "has stopped" }
+        log.info { "stopped" }
       end
 
       notifier

--- a/src/mosquito/runnable.cr
+++ b/src/mosquito/runnable.cr
@@ -155,7 +155,8 @@ module Mosquito
     # circumstances.  It will stop waiting for the spawn to exit at 25 seconds.
     # If the spawn has actually stopped the notification channel will broadcast
     # a true, otherwise false.
-    def stop : Channel(Bool) self.state = State::Stopping if state.running?
+    def stop : Channel(Bool)
+      self.state = State::Stopping if state.running?
       notifier = Channel(Bool).new
 
       spawn do
@@ -165,7 +166,7 @@ module Mosquito
         end
         notifier.send state.finished?
 
-        log.info { runnable_name + " has stopped" }
+        log.info { "has stopped" }
       end
 
       notifier

--- a/src/mosquito/runner.cr
+++ b/src/mosquito/runner.cr
@@ -50,7 +50,7 @@ module Mosquito
 
     # :nodoc:
     def self.keep_running : Bool
-      instance.state.starting? || instance.state.running?
+      instance.state.starting? || instance.state.running? || instance.state.stopping?
     end
 
     # Request the mosquito runner stop. The runner will not abort the current job

--- a/src/mosquito/runners/overseer.cr
+++ b/src/mosquito/runners/overseer.cr
@@ -84,7 +84,7 @@ module Mosquito::Runners
         executor.stop
       end
 
-      @queue_list.stop.receive
+      @queue_list.stop
 
       work_handout.close
       stopped_notifiers.each(&.receive)

--- a/src/mosquito/runners/overseer.cr
+++ b/src/mosquito/runners/overseer.cr
@@ -83,6 +83,9 @@ module Mosquito::Runners
       stopped_notifiers = executors.map do |executor|
         executor.stop
       end
+
+      @queue_list.stop.receive
+
       work_handout.close
       stopped_notifiers.each(&.receive)
       observer.stopped


### PR DESCRIPTION
There are three bugs being fixed here:

- (semantics) the queue_list runner was never being shut down -- there's no meaningful effect on this, except that it might fire off extra commands to redis unnecessarily
- (process hangs after interrupt) if an executor was mid-job during an interrupt, it would cancel it's own shutdown sequence by transitioning back to Waiting after being put into Stopping, and executor would never shutdown and the process would just hang.
- (semantics, premature exit during successful shutdown) assuming the rare condition of an executor _not_ being mid-job during interrupt, the main loop wouldn't block long enough and a full shutdown wouldn't always happen. This is mostly semantics, because the only real loss is a few error messages emitted as part of shutdown.