### PR TITLE
Updates crystal build version to 1.6.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crystal_version: [1.4, latest]
+        crystal_version: [1.4, 1.5, latest]
         experimental:
           - false
         include:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-crystal 1.14.0
+crystal 1.16.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
     `INFO - mosquito.runners.overseer.4315742080: Overseer<4315742080> is starting`
   Now the message is simply:
     `INFO - mosquito.overseer: starting`
+- Mosquito now runs CI checks for compatibility with Crystal 1.6
 ### Fixed
 - the queue_list runner was never being shut down, but it is now as of (#165)
 - Fixed a bug which would cause a mosquito server to hang at exit indefinitely if a job was mid-run during an interrupt. (#165)


### PR DESCRIPTION
This doesn't decrease support for any lower versions, but adds CI support for up to 1.6, and sets the development environment to 1.6.3. I don't think this needs a release.