### PR TITLE
Fix for worker logging `found X new queues:` repeatedly when more than 16 queues 

### DIFF
--- a/spec/mosquito/queue_spec.cr
+++ b/spec/mosquito/queue_spec.cr
@@ -208,4 +208,26 @@ describe Queue do
     end
   end
 
+  describe "equality" do
+    it "considers two instances with the same name equal" do
+      assert_equal Mosquito::Queue.new(name), Mosquito::Queue.new(name)
+    end
+
+    it "hashes instances with the same name alike" do
+      assert_equal Mosquito::Queue.new(name).hash, Mosquito::Queue.new(name).hash
+    end
+
+    it "dedupes equal-by-name instances in hash-based collections" do
+      assert_equal 1, Set{Mosquito::Queue.new(name), Mosquito::Queue.new(name)}.size
+    end
+
+    it "subtracts equal-by-name instances in hash-based Array operations" do
+      names = (1..17).map { |i| "queue_#{i}" }
+      known = names.map { |n| Mosquito::Queue.new n }
+      fresh = names.map { |n| Mosquito::Queue.new n }
+
+      assert_equal 0, (fresh - known).size
+    end
+  end
+
 end

--- a/src/mosquito/queue.cr
+++ b/src/mosquito/queue.cr
@@ -143,6 +143,10 @@ module Mosquito
       name == other.name
     end
 
+    def hash(hasher)
+      name.hash(hasher)
+    end
+
     # Pause this queue. While paused, `#dequeue` returns nil and no jobs
     # will be dispatched. Jobs can still be enqueued and will accumulate
     # until the queue is resumed.


### PR DESCRIPTION
Hey all!

I noticed an issue on my mosquito deployment when it ended up having more than 16 queues. Once the deployment went past 16 queues, the worker started logging `found 17 new queues:` every second.

I used Claude to look for the root cause. It noted that `QueueList#each_run` builds fresh `Queue` instances every 1-second tick and computes `new_queue_list - @queues`. However, Crystal's `Array#-` switches from using `#==` to a hash-based set lookup once the arrays exceed 16 elements. But here we fall back to identity hashing cause `Queue` has no `#hash` implementation, so every queue is reported as new on every tick. 

So the fix is to ensure `Queue` has a `#hash` implementation, based on `#name` just like `#==` is.

Hope that helps. Let me know if there is anything else I can do here.
